### PR TITLE
Use .NET 7 in Build_Windows CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 7.0.x
 
     - name: Restore dependencies
       run: dotnet restore src
@@ -36,7 +36,7 @@ jobs:
       shell: bash
       run: |
         echo "Running CodeGenerator"
-        bin/Release/CodeGenerator/net6.0/CodeGenerator.exe "src/ImGui.NET/Generated"
+        bin/Release/CodeGenerator/net7.0/CodeGenerator.exe "src/ImGui.NET/Generated"
         git status -s | findstr . && echo "ERROR: CodeGenerator is not executed, please execute it." && exit 1 || exit 0
 
     - name: Publish to nuget.org


### PR DESCRIPTION
The code generator was updated to .NET 7 here: https://github.com/ImGuiNET/ImGui.NET/pull/405