### PR TITLE
Use ReadOnlySpan<char> instead of string

### DIFF
--- a/src/CodeGenerator/CSharpCodeWriter.cs
+++ b/src/CodeGenerator/CSharpCodeWriter.cs
@@ -47,16 +47,6 @@ namespace CodeGenerator
             _sw.WriteLine(text);
         }
 
-        public void WriteRaw(string text)
-        {
-            _sw.WriteLine(text);
-        }
-
-        public void IndentManually()
-        {
-            _indentLevel += 4;
-        }
-
         public void Dispose()
         {
             _sw.Dispose();

--- a/src/ImGui.NET/Generated/ImFontAtlas.gen.cs
+++ b/src/ImGui.NET/Generated/ImFontAtlas.gen.cs
@@ -159,17 +159,13 @@ namespace ImGuiNET
             ImFont* ret = ImGuiNative.ImFontAtlas_AddFontDefault((ImFontAtlas*)(NativePtr), native_font_cfg);
             return new ImFontPtr(ret);
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public ImFontPtr AddFontFromFileTTF(ReadOnlySpan<char> filename, float size_pixels)
-#else
-        public ImFontPtr AddFontFromFileTTF(string filename, float size_pixels)
-#endif
         {
             byte* native_filename;
             int filename_byteCount = 0;
             if (filename != null)
             {
-                filename_byteCount = Encoding.UTF8.GetByteCount(filename);
+                filename_byteCount = Util.GetUtf8ByteCount(filename);
                 if (filename_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_filename = Util.Allocate(filename_byteCount + 1);
@@ -192,17 +188,13 @@ namespace ImGuiNET
             }
             return new ImFontPtr(ret);
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public ImFontPtr AddFontFromFileTTF(ReadOnlySpan<char> filename, float size_pixels, ImFontConfigPtr font_cfg)
-#else
-        public ImFontPtr AddFontFromFileTTF(string filename, float size_pixels, ImFontConfigPtr font_cfg)
-#endif
         {
             byte* native_filename;
             int filename_byteCount = 0;
             if (filename != null)
             {
-                filename_byteCount = Encoding.UTF8.GetByteCount(filename);
+                filename_byteCount = Util.GetUtf8ByteCount(filename);
                 if (filename_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_filename = Util.Allocate(filename_byteCount + 1);
@@ -225,17 +217,13 @@ namespace ImGuiNET
             }
             return new ImFontPtr(ret);
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public ImFontPtr AddFontFromFileTTF(ReadOnlySpan<char> filename, float size_pixels, ImFontConfigPtr font_cfg, IntPtr glyph_ranges)
-#else
-        public ImFontPtr AddFontFromFileTTF(string filename, float size_pixels, ImFontConfigPtr font_cfg, IntPtr glyph_ranges)
-#endif
         {
             byte* native_filename;
             int filename_byteCount = 0;
             if (filename != null)
             {
-                filename_byteCount = Encoding.UTF8.GetByteCount(filename);
+                filename_byteCount = Util.GetUtf8ByteCount(filename);
                 if (filename_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_filename = Util.Allocate(filename_byteCount + 1);
@@ -258,17 +246,13 @@ namespace ImGuiNET
             }
             return new ImFontPtr(ret);
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public ImFontPtr AddFontFromMemoryCompressedBase85TTF(ReadOnlySpan<char> compressed_font_data_base85, float size_pixels)
-#else
-        public ImFontPtr AddFontFromMemoryCompressedBase85TTF(string compressed_font_data_base85, float size_pixels)
-#endif
         {
             byte* native_compressed_font_data_base85;
             int compressed_font_data_base85_byteCount = 0;
             if (compressed_font_data_base85 != null)
             {
-                compressed_font_data_base85_byteCount = Encoding.UTF8.GetByteCount(compressed_font_data_base85);
+                compressed_font_data_base85_byteCount = Util.GetUtf8ByteCount(compressed_font_data_base85);
                 if (compressed_font_data_base85_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_compressed_font_data_base85 = Util.Allocate(compressed_font_data_base85_byteCount + 1);
@@ -291,17 +275,13 @@ namespace ImGuiNET
             }
             return new ImFontPtr(ret);
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public ImFontPtr AddFontFromMemoryCompressedBase85TTF(ReadOnlySpan<char> compressed_font_data_base85, float size_pixels, ImFontConfigPtr font_cfg)
-#else
-        public ImFontPtr AddFontFromMemoryCompressedBase85TTF(string compressed_font_data_base85, float size_pixels, ImFontConfigPtr font_cfg)
-#endif
         {
             byte* native_compressed_font_data_base85;
             int compressed_font_data_base85_byteCount = 0;
             if (compressed_font_data_base85 != null)
             {
-                compressed_font_data_base85_byteCount = Encoding.UTF8.GetByteCount(compressed_font_data_base85);
+                compressed_font_data_base85_byteCount = Util.GetUtf8ByteCount(compressed_font_data_base85);
                 if (compressed_font_data_base85_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_compressed_font_data_base85 = Util.Allocate(compressed_font_data_base85_byteCount + 1);
@@ -324,17 +304,13 @@ namespace ImGuiNET
             }
             return new ImFontPtr(ret);
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public ImFontPtr AddFontFromMemoryCompressedBase85TTF(ReadOnlySpan<char> compressed_font_data_base85, float size_pixels, ImFontConfigPtr font_cfg, IntPtr glyph_ranges)
-#else
-        public ImFontPtr AddFontFromMemoryCompressedBase85TTF(string compressed_font_data_base85, float size_pixels, ImFontConfigPtr font_cfg, IntPtr glyph_ranges)
-#endif
         {
             byte* native_compressed_font_data_base85;
             int compressed_font_data_base85_byteCount = 0;
             if (compressed_font_data_base85 != null)
             {
-                compressed_font_data_base85_byteCount = Encoding.UTF8.GetByteCount(compressed_font_data_base85);
+                compressed_font_data_base85_byteCount = Util.GetUtf8ByteCount(compressed_font_data_base85);
                 if (compressed_font_data_base85_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_compressed_font_data_base85 = Util.Allocate(compressed_font_data_base85_byteCount + 1);

--- a/src/ImGui.NET/Generated/ImFontGlyphRangesBuilder.gen.cs
+++ b/src/ImGui.NET/Generated/ImFontGlyphRangesBuilder.gen.cs
@@ -27,17 +27,13 @@ namespace ImGuiNET
             ushort* native_ranges = (ushort*)ranges.ToPointer();
             ImGuiNative.ImFontGlyphRangesBuilder_AddRanges((ImFontGlyphRangesBuilder*)(NativePtr), native_ranges);
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public void AddText(ReadOnlySpan<char> text)
-#else
-        public void AddText(string text)
-#endif
         {
             byte* native_text;
             int text_byteCount = 0;
             if (text != null)
             {
-                text_byteCount = Encoding.UTF8.GetByteCount(text);
+                text_byteCount = Util.GetUtf8ByteCount(text);
                 if (text_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_text = Util.Allocate(text_byteCount + 1);

--- a/src/ImGui.NET/Generated/ImGui.gen.cs
+++ b/src/ImGui.NET/Generated/ImGui.gen.cs
@@ -7,17 +7,13 @@ namespace ImGuiNET
 {
     public static unsafe partial class ImGui
     {
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static ImGuiPayloadPtr AcceptDragDropPayload(ReadOnlySpan<char> type)
-#else
-        public static ImGuiPayloadPtr AcceptDragDropPayload(string type)
-#endif
         {
             byte* native_type;
             int type_byteCount = 0;
             if (type != null)
             {
-                type_byteCount = Encoding.UTF8.GetByteCount(type);
+                type_byteCount = Util.GetUtf8ByteCount(type);
                 if (type_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_type = Util.Allocate(type_byteCount + 1);
@@ -39,17 +35,13 @@ namespace ImGuiNET
             }
             return new ImGuiPayloadPtr(ret);
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static ImGuiPayloadPtr AcceptDragDropPayload(ReadOnlySpan<char> type, ImGuiDragDropFlags flags)
-#else
-        public static ImGuiPayloadPtr AcceptDragDropPayload(string type, ImGuiDragDropFlags flags)
-#endif
         {
             byte* native_type;
             int type_byteCount = 0;
             if (type != null)
             {
-                type_byteCount = Encoding.UTF8.GetByteCount(type);
+                type_byteCount = Util.GetUtf8ByteCount(type);
                 if (type_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_type = Util.Allocate(type_byteCount + 1);
@@ -74,17 +66,13 @@ namespace ImGuiNET
         {
             ImGuiNative.igAlignTextToFramePadding();
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ArrowButton(ReadOnlySpan<char> str_id, ImGuiDir dir)
-#else
-        public static bool ArrowButton(string str_id, ImGuiDir dir)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -105,17 +93,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Begin(ReadOnlySpan<char> name)
-#else
-        public static bool Begin(string name)
-#endif
         {
             byte* native_name;
             int name_byteCount = 0;
             if (name != null)
             {
-                name_byteCount = Encoding.UTF8.GetByteCount(name);
+                name_byteCount = Util.GetUtf8ByteCount(name);
                 if (name_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_name = Util.Allocate(name_byteCount + 1);
@@ -138,17 +122,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Begin(ReadOnlySpan<char> name, ref bool p_open)
-#else
-        public static bool Begin(string name, ref bool p_open)
-#endif
         {
             byte* native_name;
             int name_byteCount = 0;
             if (name != null)
             {
-                name_byteCount = Encoding.UTF8.GetByteCount(name);
+                name_byteCount = Util.GetUtf8ByteCount(name);
                 if (name_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_name = Util.Allocate(name_byteCount + 1);
@@ -173,17 +153,13 @@ namespace ImGuiNET
             p_open = native_p_open_val != 0;
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Begin(ReadOnlySpan<char> name, ref bool p_open, ImGuiWindowFlags flags)
-#else
-        public static bool Begin(string name, ref bool p_open, ImGuiWindowFlags flags)
-#endif
         {
             byte* native_name;
             int name_byteCount = 0;
             if (name != null)
             {
-                name_byteCount = Encoding.UTF8.GetByteCount(name);
+                name_byteCount = Util.GetUtf8ByteCount(name);
                 if (name_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_name = Util.Allocate(name_byteCount + 1);
@@ -207,17 +183,13 @@ namespace ImGuiNET
             p_open = native_p_open_val != 0;
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginChild(ReadOnlySpan<char> str_id)
-#else
-        public static bool BeginChild(string str_id)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -241,17 +213,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginChild(ReadOnlySpan<char> str_id, Vector2 size)
-#else
-        public static bool BeginChild(string str_id, Vector2 size)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -274,17 +242,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginChild(ReadOnlySpan<char> str_id, Vector2 size, bool border)
-#else
-        public static bool BeginChild(string str_id, Vector2 size, bool border)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -307,17 +271,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginChild(ReadOnlySpan<char> str_id, Vector2 size, bool border, ImGuiWindowFlags flags)
-#else
-        public static bool BeginChild(string str_id, Vector2 size, bool border, ImGuiWindowFlags flags)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -378,17 +338,13 @@ namespace ImGuiNET
             byte ret = ImGuiNative.igBeginChildFrame(id, size, flags);
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginCombo(ReadOnlySpan<char> label, ReadOnlySpan<char> preview_value)
-#else
-        public static bool BeginCombo(string label, string preview_value)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -406,7 +362,7 @@ namespace ImGuiNET
             int preview_value_byteCount = 0;
             if (preview_value != null)
             {
-                preview_value_byteCount = Encoding.UTF8.GetByteCount(preview_value);
+                preview_value_byteCount = Util.GetUtf8ByteCount(preview_value);
                 if (preview_value_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_preview_value = Util.Allocate(preview_value_byteCount + 1);
@@ -432,17 +388,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginCombo(ReadOnlySpan<char> label, ReadOnlySpan<char> preview_value, ImGuiComboFlags flags)
-#else
-        public static bool BeginCombo(string label, string preview_value, ImGuiComboFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -460,7 +412,7 @@ namespace ImGuiNET
             int preview_value_byteCount = 0;
             if (preview_value != null)
             {
-                preview_value_byteCount = Encoding.UTF8.GetByteCount(preview_value);
+                preview_value_byteCount = Util.GetUtf8ByteCount(preview_value);
                 if (preview_value_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_preview_value = Util.Allocate(preview_value_byteCount + 1);
@@ -515,17 +467,13 @@ namespace ImGuiNET
         {
             ImGuiNative.igBeginGroup();
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginListBox(ReadOnlySpan<char> label)
-#else
-        public static bool BeginListBox(string label)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -547,17 +495,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginListBox(ReadOnlySpan<char> label, Vector2 size)
-#else
-        public static bool BeginListBox(string label, Vector2 size)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -583,17 +527,13 @@ namespace ImGuiNET
             byte ret = ImGuiNative.igBeginMainMenuBar();
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginMenu(ReadOnlySpan<char> label)
-#else
-        public static bool BeginMenu(string label)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -615,17 +555,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginMenu(ReadOnlySpan<char> label, bool enabled)
-#else
-        public static bool BeginMenu(string label, bool enabled)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -652,17 +588,13 @@ namespace ImGuiNET
             byte ret = ImGuiNative.igBeginMenuBar();
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginPopup(ReadOnlySpan<char> str_id)
-#else
-        public static bool BeginPopup(string str_id)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -684,17 +616,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginPopup(ReadOnlySpan<char> str_id, ImGuiWindowFlags flags)
-#else
-        public static bool BeginPopup(string str_id, ImGuiWindowFlags flags)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -722,17 +650,13 @@ namespace ImGuiNET
             byte ret = ImGuiNative.igBeginPopupContextItem(native_str_id, popup_flags);
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginPopupContextItem(ReadOnlySpan<char> str_id)
-#else
-        public static bool BeginPopupContextItem(string str_id)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -754,17 +678,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginPopupContextItem(ReadOnlySpan<char> str_id, ImGuiPopupFlags popup_flags)
-#else
-        public static bool BeginPopupContextItem(string str_id, ImGuiPopupFlags popup_flags)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -792,17 +712,13 @@ namespace ImGuiNET
             byte ret = ImGuiNative.igBeginPopupContextVoid(native_str_id, popup_flags);
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginPopupContextVoid(ReadOnlySpan<char> str_id)
-#else
-        public static bool BeginPopupContextVoid(string str_id)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -824,17 +740,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginPopupContextVoid(ReadOnlySpan<char> str_id, ImGuiPopupFlags popup_flags)
-#else
-        public static bool BeginPopupContextVoid(string str_id, ImGuiPopupFlags popup_flags)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -862,17 +774,13 @@ namespace ImGuiNET
             byte ret = ImGuiNative.igBeginPopupContextWindow(native_str_id, popup_flags);
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginPopupContextWindow(ReadOnlySpan<char> str_id)
-#else
-        public static bool BeginPopupContextWindow(string str_id)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -894,17 +802,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginPopupContextWindow(ReadOnlySpan<char> str_id, ImGuiPopupFlags popup_flags)
-#else
-        public static bool BeginPopupContextWindow(string str_id, ImGuiPopupFlags popup_flags)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -925,17 +829,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginPopupModal(ReadOnlySpan<char> name)
-#else
-        public static bool BeginPopupModal(string name)
-#endif
         {
             byte* native_name;
             int name_byteCount = 0;
             if (name != null)
             {
-                name_byteCount = Encoding.UTF8.GetByteCount(name);
+                name_byteCount = Util.GetUtf8ByteCount(name);
                 if (name_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_name = Util.Allocate(name_byteCount + 1);
@@ -958,17 +858,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginPopupModal(ReadOnlySpan<char> name, ref bool p_open)
-#else
-        public static bool BeginPopupModal(string name, ref bool p_open)
-#endif
         {
             byte* native_name;
             int name_byteCount = 0;
             if (name != null)
             {
-                name_byteCount = Encoding.UTF8.GetByteCount(name);
+                name_byteCount = Util.GetUtf8ByteCount(name);
                 if (name_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_name = Util.Allocate(name_byteCount + 1);
@@ -993,17 +889,13 @@ namespace ImGuiNET
             p_open = native_p_open_val != 0;
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginPopupModal(ReadOnlySpan<char> name, ref bool p_open, ImGuiWindowFlags flags)
-#else
-        public static bool BeginPopupModal(string name, ref bool p_open, ImGuiWindowFlags flags)
-#endif
         {
             byte* native_name;
             int name_byteCount = 0;
             if (name != null)
             {
-                name_byteCount = Encoding.UTF8.GetByteCount(name);
+                name_byteCount = Util.GetUtf8ByteCount(name);
                 if (name_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_name = Util.Allocate(name_byteCount + 1);
@@ -1027,17 +919,13 @@ namespace ImGuiNET
             p_open = native_p_open_val != 0;
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginTabBar(ReadOnlySpan<char> str_id)
-#else
-        public static bool BeginTabBar(string str_id)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -1059,17 +947,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginTabBar(ReadOnlySpan<char> str_id, ImGuiTabBarFlags flags)
-#else
-        public static bool BeginTabBar(string str_id, ImGuiTabBarFlags flags)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -1090,17 +974,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginTabItem(ReadOnlySpan<char> label)
-#else
-        public static bool BeginTabItem(string label)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -1123,17 +1003,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginTabItem(ReadOnlySpan<char> label, ref bool p_open)
-#else
-        public static bool BeginTabItem(string label, ref bool p_open)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -1158,17 +1034,13 @@ namespace ImGuiNET
             p_open = native_p_open_val != 0;
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginTabItem(ReadOnlySpan<char> label, ref bool p_open, ImGuiTabItemFlags flags)
-#else
-        public static bool BeginTabItem(string label, ref bool p_open, ImGuiTabItemFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -1192,17 +1064,13 @@ namespace ImGuiNET
             p_open = native_p_open_val != 0;
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginTable(ReadOnlySpan<char> str_id, int column)
-#else
-        public static bool BeginTable(string str_id, int column)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -1226,17 +1094,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginTable(ReadOnlySpan<char> str_id, int column, ImGuiTableFlags flags)
-#else
-        public static bool BeginTable(string str_id, int column, ImGuiTableFlags flags)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -1259,17 +1123,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginTable(ReadOnlySpan<char> str_id, int column, ImGuiTableFlags flags, Vector2 outer_size)
-#else
-        public static bool BeginTable(string str_id, int column, ImGuiTableFlags flags, Vector2 outer_size)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -1291,17 +1151,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginTable(ReadOnlySpan<char> str_id, int column, ImGuiTableFlags flags, Vector2 outer_size, float inner_width)
-#else
-        public static bool BeginTable(string str_id, int column, ImGuiTableFlags flags, Vector2 outer_size, float inner_width)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -1331,17 +1187,13 @@ namespace ImGuiNET
         {
             ImGuiNative.igBullet();
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void BulletText(ReadOnlySpan<char> fmt)
-#else
-        public static void BulletText(string fmt)
-#endif
         {
             byte* native_fmt;
             int fmt_byteCount = 0;
             if (fmt != null)
             {
-                fmt_byteCount = Encoding.UTF8.GetByteCount(fmt);
+                fmt_byteCount = Util.GetUtf8ByteCount(fmt);
                 if (fmt_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_fmt = Util.Allocate(fmt_byteCount + 1);
@@ -1361,17 +1213,13 @@ namespace ImGuiNET
                 Util.Free(native_fmt);
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Button(ReadOnlySpan<char> label)
-#else
-        public static bool Button(string label)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -1393,17 +1241,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Button(ReadOnlySpan<char> label, Vector2 size)
-#else
-        public static bool Button(string label, Vector2 size)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -1429,17 +1273,13 @@ namespace ImGuiNET
             float ret = ImGuiNative.igCalcItemWidth();
             return ret;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Checkbox(ReadOnlySpan<char> label, ref bool v)
-#else
-        public static bool Checkbox(string label, ref bool v)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -1463,17 +1303,13 @@ namespace ImGuiNET
             v = native_v_val != 0;
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool CheckboxFlags(ReadOnlySpan<char> label, ref int flags, int flags_value)
-#else
-        public static bool CheckboxFlags(string label, ref int flags, int flags_value)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -1497,17 +1333,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool CheckboxFlags(ReadOnlySpan<char> label, ref uint flags, uint flags_value)
-#else
-        public static bool CheckboxFlags(string label, ref uint flags, uint flags_value)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -1535,17 +1367,13 @@ namespace ImGuiNET
         {
             ImGuiNative.igCloseCurrentPopup();
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool CollapsingHeader(ReadOnlySpan<char> label)
-#else
-        public static bool CollapsingHeader(string label)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -1567,17 +1395,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool CollapsingHeader(ReadOnlySpan<char> label, ImGuiTreeNodeFlags flags)
-#else
-        public static bool CollapsingHeader(string label, ImGuiTreeNodeFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -1598,17 +1422,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool CollapsingHeader(ReadOnlySpan<char> label, ref bool p_visible)
-#else
-        public static bool CollapsingHeader(string label, ref bool p_visible)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -1633,17 +1453,13 @@ namespace ImGuiNET
             p_visible = native_p_visible_val != 0;
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool CollapsingHeader(ReadOnlySpan<char> label, ref bool p_visible, ImGuiTreeNodeFlags flags)
-#else
-        public static bool CollapsingHeader(string label, ref bool p_visible, ImGuiTreeNodeFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -1667,17 +1483,13 @@ namespace ImGuiNET
             p_visible = native_p_visible_val != 0;
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ColorButton(ReadOnlySpan<char> desc_id, Vector4 col)
-#else
-        public static bool ColorButton(string desc_id, Vector4 col)
-#endif
         {
             byte* native_desc_id;
             int desc_id_byteCount = 0;
             if (desc_id != null)
             {
-                desc_id_byteCount = Encoding.UTF8.GetByteCount(desc_id);
+                desc_id_byteCount = Util.GetUtf8ByteCount(desc_id);
                 if (desc_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_desc_id = Util.Allocate(desc_id_byteCount + 1);
@@ -1700,17 +1512,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ColorButton(ReadOnlySpan<char> desc_id, Vector4 col, ImGuiColorEditFlags flags)
-#else
-        public static bool ColorButton(string desc_id, Vector4 col, ImGuiColorEditFlags flags)
-#endif
         {
             byte* native_desc_id;
             int desc_id_byteCount = 0;
             if (desc_id != null)
             {
-                desc_id_byteCount = Encoding.UTF8.GetByteCount(desc_id);
+                desc_id_byteCount = Util.GetUtf8ByteCount(desc_id);
                 if (desc_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_desc_id = Util.Allocate(desc_id_byteCount + 1);
@@ -1732,17 +1540,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ColorButton(ReadOnlySpan<char> desc_id, Vector4 col, ImGuiColorEditFlags flags, Vector2 size)
-#else
-        public static bool ColorButton(string desc_id, Vector4 col, ImGuiColorEditFlags flags, Vector2 size)
-#endif
         {
             byte* native_desc_id;
             int desc_id_byteCount = 0;
             if (desc_id != null)
             {
-                desc_id_byteCount = Encoding.UTF8.GetByteCount(desc_id);
+                desc_id_byteCount = Util.GetUtf8ByteCount(desc_id);
                 if (desc_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_desc_id = Util.Allocate(desc_id_byteCount + 1);
@@ -1800,17 +1604,13 @@ namespace ImGuiNET
             ImGuiNative.igColorConvertU32ToFloat4(&__retval, @in);
             return __retval;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ColorEdit3(ReadOnlySpan<char> label, ref Vector3 col)
-#else
-        public static bool ColorEdit3(string label, ref Vector3 col)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -1835,17 +1635,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ColorEdit3(ReadOnlySpan<char> label, ref Vector3 col, ImGuiColorEditFlags flags)
-#else
-        public static bool ColorEdit3(string label, ref Vector3 col, ImGuiColorEditFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -1869,17 +1665,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ColorEdit4(ReadOnlySpan<char> label, ref Vector4 col)
-#else
-        public static bool ColorEdit4(string label, ref Vector4 col)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -1904,17 +1696,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ColorEdit4(ReadOnlySpan<char> label, ref Vector4 col, ImGuiColorEditFlags flags)
-#else
-        public static bool ColorEdit4(string label, ref Vector4 col, ImGuiColorEditFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -1938,17 +1726,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ColorPicker3(ReadOnlySpan<char> label, ref Vector3 col)
-#else
-        public static bool ColorPicker3(string label, ref Vector3 col)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -1973,17 +1757,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ColorPicker3(ReadOnlySpan<char> label, ref Vector3 col, ImGuiColorEditFlags flags)
-#else
-        public static bool ColorPicker3(string label, ref Vector3 col, ImGuiColorEditFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -2007,17 +1787,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ColorPicker4(ReadOnlySpan<char> label, ref Vector4 col)
-#else
-        public static bool ColorPicker4(string label, ref Vector4 col)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -2043,17 +1819,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ColorPicker4(ReadOnlySpan<char> label, ref Vector4 col, ImGuiColorEditFlags flags)
-#else
-        public static bool ColorPicker4(string label, ref Vector4 col, ImGuiColorEditFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -2078,17 +1850,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ColorPicker4(ReadOnlySpan<char> label, ref Vector4 col, ImGuiColorEditFlags flags, ref float ref_col)
-#else
-        public static bool ColorPicker4(string label, ref Vector4 col, ImGuiColorEditFlags flags, ref float ref_col)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -2128,17 +1896,13 @@ namespace ImGuiNET
             byte border = 1;
             ImGuiNative.igColumns(count, native_id, border);
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void Columns(int count, ReadOnlySpan<char> id)
-#else
-        public static void Columns(int count, string id)
-#endif
         {
             byte* native_id;
             int id_byteCount = 0;
             if (id != null)
             {
-                id_byteCount = Encoding.UTF8.GetByteCount(id);
+                id_byteCount = Util.GetUtf8ByteCount(id);
                 if (id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_id = Util.Allocate(id_byteCount + 1);
@@ -2159,17 +1923,13 @@ namespace ImGuiNET
                 Util.Free(native_id);
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void Columns(int count, ReadOnlySpan<char> id, bool border)
-#else
-        public static void Columns(int count, string id, bool border)
-#endif
         {
             byte* native_id;
             int id_byteCount = 0;
             if (id != null)
             {
-                id_byteCount = Encoding.UTF8.GetByteCount(id);
+                id_byteCount = Util.GetUtf8ByteCount(id);
                 if (id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_id = Util.Allocate(id_byteCount + 1);
@@ -2190,17 +1950,13 @@ namespace ImGuiNET
                 Util.Free(native_id);
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Combo(ReadOnlySpan<char> label, ref int current_item, string[] items, int items_count)
-#else
-        public static bool Combo(string label, ref int current_item, string[] items, int items_count)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -2219,7 +1975,7 @@ namespace ImGuiNET
             for (int i = 0; i < items.Length; i++)
             {
                 string s = items[i];
-                items_byteCounts[i] = Encoding.UTF8.GetByteCount(s);
+                items_byteCounts[i] = Util.GetUtf8ByteCount(s);
                 items_byteCount += items_byteCounts[i] + 1;
             }
             byte* native_items_data = stackalloc byte[items_byteCount];
@@ -2252,17 +2008,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Combo(ReadOnlySpan<char> label, ref int current_item, string[] items, int items_count, int popup_max_height_in_items)
-#else
-        public static bool Combo(string label, ref int current_item, string[] items, int items_count, int popup_max_height_in_items)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -2281,7 +2033,7 @@ namespace ImGuiNET
             for (int i = 0; i < items.Length; i++)
             {
                 string s = items[i];
-                items_byteCounts[i] = Encoding.UTF8.GetByteCount(s);
+                items_byteCounts[i] = Util.GetUtf8ByteCount(s);
                 items_byteCount += items_byteCounts[i] + 1;
             }
             byte* native_items_data = stackalloc byte[items_byteCount];
@@ -2313,17 +2065,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Combo(ReadOnlySpan<char> label, ref int current_item, ReadOnlySpan<char> items_separated_by_zeros)
-#else
-        public static bool Combo(string label, ref int current_item, string items_separated_by_zeros)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -2341,7 +2089,7 @@ namespace ImGuiNET
             int items_separated_by_zeros_byteCount = 0;
             if (items_separated_by_zeros != null)
             {
-                items_separated_by_zeros_byteCount = Encoding.UTF8.GetByteCount(items_separated_by_zeros);
+                items_separated_by_zeros_byteCount = Util.GetUtf8ByteCount(items_separated_by_zeros);
                 if (items_separated_by_zeros_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_items_separated_by_zeros = Util.Allocate(items_separated_by_zeros_byteCount + 1);
@@ -2370,17 +2118,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Combo(ReadOnlySpan<char> label, ref int current_item, ReadOnlySpan<char> items_separated_by_zeros, int popup_max_height_in_items)
-#else
-        public static bool Combo(string label, ref int current_item, string items_separated_by_zeros, int popup_max_height_in_items)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -2398,7 +2142,7 @@ namespace ImGuiNET
             int items_separated_by_zeros_byteCount = 0;
             if (items_separated_by_zeros != null)
             {
-                items_separated_by_zeros_byteCount = Encoding.UTF8.GetByteCount(items_separated_by_zeros);
+                items_separated_by_zeros_byteCount = Util.GetUtf8ByteCount(items_separated_by_zeros);
                 if (items_separated_by_zeros_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_items_separated_by_zeros = Util.Allocate(items_separated_by_zeros_byteCount + 1);
@@ -2438,17 +2182,13 @@ namespace ImGuiNET
             IntPtr ret = ImGuiNative.igCreateContext(native_shared_font_atlas);
             return ret;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DebugCheckVersionAndDataLayout(ReadOnlySpan<char> version_str, uint sz_io, uint sz_style, uint sz_vec2, uint sz_vec4, uint sz_drawvert, uint sz_drawidx)
-#else
-        public static bool DebugCheckVersionAndDataLayout(string version_str, uint sz_io, uint sz_style, uint sz_vec2, uint sz_vec4, uint sz_drawvert, uint sz_drawidx)
-#endif
         {
             byte* native_version_str;
             int version_str_byteCount = 0;
             if (version_str != null)
             {
-                version_str_byteCount = Encoding.UTF8.GetByteCount(version_str);
+                version_str_byteCount = Util.GetUtf8ByteCount(version_str);
                 if (version_str_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_version_str = Util.Allocate(version_str_byteCount + 1);
@@ -2469,17 +2209,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void DebugTextEncoding(ReadOnlySpan<char> text)
-#else
-        public static void DebugTextEncoding(string text)
-#endif
         {
             byte* native_text;
             int text_byteCount = 0;
             if (text != null)
             {
-                text_byteCount = Encoding.UTF8.GetByteCount(text);
+                text_byteCount = Util.GetUtf8ByteCount(text);
                 if (text_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_text = Util.Allocate(text_byteCount + 1);
@@ -2569,17 +2305,13 @@ namespace ImGuiNET
             uint ret = ImGuiNative.igDockSpaceOverViewport(native_viewport, flags, native_window_class);
             return ret;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat(ReadOnlySpan<char> label, ref float v)
-#else
-        public static bool DragFloat(string label, ref float v)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -2598,7 +2330,7 @@ namespace ImGuiNET
             float v_max = 0.0f;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                format_byteCount = Util.GetUtf8ByteCount("%.3f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -2625,17 +2357,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat(ReadOnlySpan<char> label, ref float v, float v_speed)
-#else
-        public static bool DragFloat(string label, ref float v, float v_speed)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -2653,7 +2381,7 @@ namespace ImGuiNET
             float v_max = 0.0f;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                format_byteCount = Util.GetUtf8ByteCount("%.3f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -2680,17 +2408,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat(ReadOnlySpan<char> label, ref float v, float v_speed, float v_min)
-#else
-        public static bool DragFloat(string label, ref float v, float v_speed, float v_min)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -2707,7 +2431,7 @@ namespace ImGuiNET
             float v_max = 0.0f;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                format_byteCount = Util.GetUtf8ByteCount("%.3f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -2734,17 +2458,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat(ReadOnlySpan<char> label, ref float v, float v_speed, float v_min, float v_max)
-#else
-        public static bool DragFloat(string label, ref float v, float v_speed, float v_min, float v_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -2760,7 +2480,7 @@ namespace ImGuiNET
             else { native_label = null; }
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                format_byteCount = Util.GetUtf8ByteCount("%.3f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -2787,17 +2507,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat(ReadOnlySpan<char> label, ref float v, float v_speed, float v_min, float v_max, ReadOnlySpan<char> format)
-#else
-        public static bool DragFloat(string label, ref float v, float v_speed, float v_min, float v_max, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -2815,7 +2531,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -2844,17 +2560,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat(ReadOnlySpan<char> label, ref float v, float v_speed, float v_min, float v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool DragFloat(string label, ref float v, float v_speed, float v_min, float v_max, string format, ImGuiSliderFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -2872,7 +2584,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -2900,17 +2612,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat2(ReadOnlySpan<char> label, ref Vector2 v)
-#else
-        public static bool DragFloat2(string label, ref Vector2 v)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -2929,7 +2637,7 @@ namespace ImGuiNET
             float v_max = 0.0f;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                format_byteCount = Util.GetUtf8ByteCount("%.3f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -2956,17 +2664,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat2(ReadOnlySpan<char> label, ref Vector2 v, float v_speed)
-#else
-        public static bool DragFloat2(string label, ref Vector2 v, float v_speed)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -2984,7 +2688,7 @@ namespace ImGuiNET
             float v_max = 0.0f;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                format_byteCount = Util.GetUtf8ByteCount("%.3f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -3011,17 +2715,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat2(ReadOnlySpan<char> label, ref Vector2 v, float v_speed, float v_min)
-#else
-        public static bool DragFloat2(string label, ref Vector2 v, float v_speed, float v_min)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -3038,7 +2738,7 @@ namespace ImGuiNET
             float v_max = 0.0f;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                format_byteCount = Util.GetUtf8ByteCount("%.3f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -3065,17 +2765,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat2(ReadOnlySpan<char> label, ref Vector2 v, float v_speed, float v_min, float v_max)
-#else
-        public static bool DragFloat2(string label, ref Vector2 v, float v_speed, float v_min, float v_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -3091,7 +2787,7 @@ namespace ImGuiNET
             else { native_label = null; }
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                format_byteCount = Util.GetUtf8ByteCount("%.3f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -3118,17 +2814,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat2(ReadOnlySpan<char> label, ref Vector2 v, float v_speed, float v_min, float v_max, ReadOnlySpan<char> format)
-#else
-        public static bool DragFloat2(string label, ref Vector2 v, float v_speed, float v_min, float v_max, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -3146,7 +2838,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -3175,17 +2867,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat2(ReadOnlySpan<char> label, ref Vector2 v, float v_speed, float v_min, float v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool DragFloat2(string label, ref Vector2 v, float v_speed, float v_min, float v_max, string format, ImGuiSliderFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -3203,7 +2891,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -3231,17 +2919,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat3(ReadOnlySpan<char> label, ref Vector3 v)
-#else
-        public static bool DragFloat3(string label, ref Vector3 v)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -3260,7 +2944,7 @@ namespace ImGuiNET
             float v_max = 0.0f;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                format_byteCount = Util.GetUtf8ByteCount("%.3f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -3287,17 +2971,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat3(ReadOnlySpan<char> label, ref Vector3 v, float v_speed)
-#else
-        public static bool DragFloat3(string label, ref Vector3 v, float v_speed)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -3315,7 +2995,7 @@ namespace ImGuiNET
             float v_max = 0.0f;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                format_byteCount = Util.GetUtf8ByteCount("%.3f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -3342,17 +3022,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat3(ReadOnlySpan<char> label, ref Vector3 v, float v_speed, float v_min)
-#else
-        public static bool DragFloat3(string label, ref Vector3 v, float v_speed, float v_min)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -3369,7 +3045,7 @@ namespace ImGuiNET
             float v_max = 0.0f;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                format_byteCount = Util.GetUtf8ByteCount("%.3f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -3396,17 +3072,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat3(ReadOnlySpan<char> label, ref Vector3 v, float v_speed, float v_min, float v_max)
-#else
-        public static bool DragFloat3(string label, ref Vector3 v, float v_speed, float v_min, float v_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -3422,7 +3094,7 @@ namespace ImGuiNET
             else { native_label = null; }
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                format_byteCount = Util.GetUtf8ByteCount("%.3f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -3449,17 +3121,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat3(ReadOnlySpan<char> label, ref Vector3 v, float v_speed, float v_min, float v_max, ReadOnlySpan<char> format)
-#else
-        public static bool DragFloat3(string label, ref Vector3 v, float v_speed, float v_min, float v_max, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -3477,7 +3145,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -3506,17 +3174,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat3(ReadOnlySpan<char> label, ref Vector3 v, float v_speed, float v_min, float v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool DragFloat3(string label, ref Vector3 v, float v_speed, float v_min, float v_max, string format, ImGuiSliderFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -3534,7 +3198,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -3562,17 +3226,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat4(ReadOnlySpan<char> label, ref Vector4 v)
-#else
-        public static bool DragFloat4(string label, ref Vector4 v)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -3591,7 +3251,7 @@ namespace ImGuiNET
             float v_max = 0.0f;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                format_byteCount = Util.GetUtf8ByteCount("%.3f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -3618,17 +3278,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat4(ReadOnlySpan<char> label, ref Vector4 v, float v_speed)
-#else
-        public static bool DragFloat4(string label, ref Vector4 v, float v_speed)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -3646,7 +3302,7 @@ namespace ImGuiNET
             float v_max = 0.0f;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                format_byteCount = Util.GetUtf8ByteCount("%.3f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -3673,17 +3329,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat4(ReadOnlySpan<char> label, ref Vector4 v, float v_speed, float v_min)
-#else
-        public static bool DragFloat4(string label, ref Vector4 v, float v_speed, float v_min)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -3700,7 +3352,7 @@ namespace ImGuiNET
             float v_max = 0.0f;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                format_byteCount = Util.GetUtf8ByteCount("%.3f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -3727,17 +3379,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat4(ReadOnlySpan<char> label, ref Vector4 v, float v_speed, float v_min, float v_max)
-#else
-        public static bool DragFloat4(string label, ref Vector4 v, float v_speed, float v_min, float v_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -3753,7 +3401,7 @@ namespace ImGuiNET
             else { native_label = null; }
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                format_byteCount = Util.GetUtf8ByteCount("%.3f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -3780,17 +3428,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat4(ReadOnlySpan<char> label, ref Vector4 v, float v_speed, float v_min, float v_max, ReadOnlySpan<char> format)
-#else
-        public static bool DragFloat4(string label, ref Vector4 v, float v_speed, float v_min, float v_max, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -3808,7 +3452,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -3837,17 +3481,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat4(ReadOnlySpan<char> label, ref Vector4 v, float v_speed, float v_min, float v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool DragFloat4(string label, ref Vector4 v, float v_speed, float v_min, float v_max, string format, ImGuiSliderFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -3865,7 +3505,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -3893,17 +3533,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloatRange2(ReadOnlySpan<char> label, ref float v_current_min, ref float v_current_max)
-#else
-        public static bool DragFloatRange2(string label, ref float v_current_min, ref float v_current_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -3922,7 +3558,7 @@ namespace ImGuiNET
             float v_max = 0.0f;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                format_byteCount = Util.GetUtf8ByteCount("%.3f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -3953,17 +3589,13 @@ namespace ImGuiNET
                 }
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloatRange2(ReadOnlySpan<char> label, ref float v_current_min, ref float v_current_max, float v_speed)
-#else
-        public static bool DragFloatRange2(string label, ref float v_current_min, ref float v_current_max, float v_speed)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -3981,7 +3613,7 @@ namespace ImGuiNET
             float v_max = 0.0f;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                format_byteCount = Util.GetUtf8ByteCount("%.3f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -4012,17 +3644,13 @@ namespace ImGuiNET
                 }
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloatRange2(ReadOnlySpan<char> label, ref float v_current_min, ref float v_current_max, float v_speed, float v_min)
-#else
-        public static bool DragFloatRange2(string label, ref float v_current_min, ref float v_current_max, float v_speed, float v_min)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -4039,7 +3667,7 @@ namespace ImGuiNET
             float v_max = 0.0f;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                format_byteCount = Util.GetUtf8ByteCount("%.3f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -4070,17 +3698,13 @@ namespace ImGuiNET
                 }
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloatRange2(ReadOnlySpan<char> label, ref float v_current_min, ref float v_current_max, float v_speed, float v_min, float v_max)
-#else
-        public static bool DragFloatRange2(string label, ref float v_current_min, ref float v_current_max, float v_speed, float v_min, float v_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -4096,7 +3720,7 @@ namespace ImGuiNET
             else { native_label = null; }
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                format_byteCount = Util.GetUtf8ByteCount("%.3f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -4127,17 +3751,13 @@ namespace ImGuiNET
                 }
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloatRange2(ReadOnlySpan<char> label, ref float v_current_min, ref float v_current_max, float v_speed, float v_min, float v_max, ReadOnlySpan<char> format)
-#else
-        public static bool DragFloatRange2(string label, ref float v_current_min, ref float v_current_max, float v_speed, float v_min, float v_max, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -4155,7 +3775,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -4188,17 +3808,13 @@ namespace ImGuiNET
                 }
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloatRange2(ReadOnlySpan<char> label, ref float v_current_min, ref float v_current_max, float v_speed, float v_min, float v_max, ReadOnlySpan<char> format, ReadOnlySpan<char> format_max)
-#else
-        public static bool DragFloatRange2(string label, ref float v_current_min, ref float v_current_max, float v_speed, float v_min, float v_max, string format, string format_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -4216,7 +3832,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -4234,7 +3850,7 @@ namespace ImGuiNET
             int format_max_byteCount = 0;
             if (format_max != null)
             {
-                format_max_byteCount = Encoding.UTF8.GetByteCount(format_max);
+                format_max_byteCount = Util.GetUtf8ByteCount(format_max);
                 if (format_max_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format_max = Util.Allocate(format_max_byteCount + 1);
@@ -4270,17 +3886,13 @@ namespace ImGuiNET
                 }
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloatRange2(ReadOnlySpan<char> label, ref float v_current_min, ref float v_current_max, float v_speed, float v_min, float v_max, ReadOnlySpan<char> format, ReadOnlySpan<char> format_max, ImGuiSliderFlags flags)
-#else
-        public static bool DragFloatRange2(string label, ref float v_current_min, ref float v_current_max, float v_speed, float v_min, float v_max, string format, string format_max, ImGuiSliderFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -4298,7 +3910,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -4316,7 +3928,7 @@ namespace ImGuiNET
             int format_max_byteCount = 0;
             if (format_max != null)
             {
-                format_max_byteCount = Encoding.UTF8.GetByteCount(format_max);
+                format_max_byteCount = Util.GetUtf8ByteCount(format_max);
                 if (format_max_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format_max = Util.Allocate(format_max_byteCount + 1);
@@ -4351,17 +3963,13 @@ namespace ImGuiNET
                 }
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt(ReadOnlySpan<char> label, ref int v)
-#else
-        public static bool DragInt(string label, ref int v)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -4380,7 +3988,7 @@ namespace ImGuiNET
             int v_max = 0;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                format_byteCount = Util.GetUtf8ByteCount("%d");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -4407,17 +4015,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt(ReadOnlySpan<char> label, ref int v, float v_speed)
-#else
-        public static bool DragInt(string label, ref int v, float v_speed)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -4435,7 +4039,7 @@ namespace ImGuiNET
             int v_max = 0;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                format_byteCount = Util.GetUtf8ByteCount("%d");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -4462,17 +4066,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min)
-#else
-        public static bool DragInt(string label, ref int v, float v_speed, int v_min)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -4489,7 +4089,7 @@ namespace ImGuiNET
             int v_max = 0;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                format_byteCount = Util.GetUtf8ByteCount("%d");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -4516,17 +4116,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min, int v_max)
-#else
-        public static bool DragInt(string label, ref int v, float v_speed, int v_min, int v_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -4542,7 +4138,7 @@ namespace ImGuiNET
             else { native_label = null; }
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                format_byteCount = Util.GetUtf8ByteCount("%d");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -4569,17 +4165,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min, int v_max, ReadOnlySpan<char> format)
-#else
-        public static bool DragInt(string label, ref int v, float v_speed, int v_min, int v_max, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -4597,7 +4189,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -4626,17 +4218,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min, int v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool DragInt(string label, ref int v, float v_speed, int v_min, int v_max, string format, ImGuiSliderFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -4654,7 +4242,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -4682,17 +4270,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt2(ReadOnlySpan<char> label, ref int v)
-#else
-        public static bool DragInt2(string label, ref int v)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -4711,7 +4295,7 @@ namespace ImGuiNET
             int v_max = 0;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                format_byteCount = Util.GetUtf8ByteCount("%d");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -4738,17 +4322,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt2(ReadOnlySpan<char> label, ref int v, float v_speed)
-#else
-        public static bool DragInt2(string label, ref int v, float v_speed)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -4766,7 +4346,7 @@ namespace ImGuiNET
             int v_max = 0;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                format_byteCount = Util.GetUtf8ByteCount("%d");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -4793,17 +4373,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt2(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min)
-#else
-        public static bool DragInt2(string label, ref int v, float v_speed, int v_min)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -4820,7 +4396,7 @@ namespace ImGuiNET
             int v_max = 0;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                format_byteCount = Util.GetUtf8ByteCount("%d");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -4847,17 +4423,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt2(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min, int v_max)
-#else
-        public static bool DragInt2(string label, ref int v, float v_speed, int v_min, int v_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -4873,7 +4445,7 @@ namespace ImGuiNET
             else { native_label = null; }
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                format_byteCount = Util.GetUtf8ByteCount("%d");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -4900,17 +4472,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt2(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min, int v_max, ReadOnlySpan<char> format)
-#else
-        public static bool DragInt2(string label, ref int v, float v_speed, int v_min, int v_max, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -4928,7 +4496,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -4957,17 +4525,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt2(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min, int v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool DragInt2(string label, ref int v, float v_speed, int v_min, int v_max, string format, ImGuiSliderFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -4985,7 +4549,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -5013,17 +4577,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt3(ReadOnlySpan<char> label, ref int v)
-#else
-        public static bool DragInt3(string label, ref int v)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -5042,7 +4602,7 @@ namespace ImGuiNET
             int v_max = 0;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                format_byteCount = Util.GetUtf8ByteCount("%d");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -5069,17 +4629,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt3(ReadOnlySpan<char> label, ref int v, float v_speed)
-#else
-        public static bool DragInt3(string label, ref int v, float v_speed)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -5097,7 +4653,7 @@ namespace ImGuiNET
             int v_max = 0;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                format_byteCount = Util.GetUtf8ByteCount("%d");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -5124,17 +4680,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt3(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min)
-#else
-        public static bool DragInt3(string label, ref int v, float v_speed, int v_min)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -5151,7 +4703,7 @@ namespace ImGuiNET
             int v_max = 0;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                format_byteCount = Util.GetUtf8ByteCount("%d");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -5178,17 +4730,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt3(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min, int v_max)
-#else
-        public static bool DragInt3(string label, ref int v, float v_speed, int v_min, int v_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -5204,7 +4752,7 @@ namespace ImGuiNET
             else { native_label = null; }
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                format_byteCount = Util.GetUtf8ByteCount("%d");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -5231,17 +4779,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt3(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min, int v_max, ReadOnlySpan<char> format)
-#else
-        public static bool DragInt3(string label, ref int v, float v_speed, int v_min, int v_max, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -5259,7 +4803,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -5288,17 +4832,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt3(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min, int v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool DragInt3(string label, ref int v, float v_speed, int v_min, int v_max, string format, ImGuiSliderFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -5316,7 +4856,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -5344,17 +4884,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt4(ReadOnlySpan<char> label, ref int v)
-#else
-        public static bool DragInt4(string label, ref int v)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -5373,7 +4909,7 @@ namespace ImGuiNET
             int v_max = 0;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                format_byteCount = Util.GetUtf8ByteCount("%d");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -5400,17 +4936,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt4(ReadOnlySpan<char> label, ref int v, float v_speed)
-#else
-        public static bool DragInt4(string label, ref int v, float v_speed)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -5428,7 +4960,7 @@ namespace ImGuiNET
             int v_max = 0;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                format_byteCount = Util.GetUtf8ByteCount("%d");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -5455,17 +4987,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt4(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min)
-#else
-        public static bool DragInt4(string label, ref int v, float v_speed, int v_min)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -5482,7 +5010,7 @@ namespace ImGuiNET
             int v_max = 0;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                format_byteCount = Util.GetUtf8ByteCount("%d");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -5509,17 +5037,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt4(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min, int v_max)
-#else
-        public static bool DragInt4(string label, ref int v, float v_speed, int v_min, int v_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -5535,7 +5059,7 @@ namespace ImGuiNET
             else { native_label = null; }
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                format_byteCount = Util.GetUtf8ByteCount("%d");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -5562,17 +5086,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt4(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min, int v_max, ReadOnlySpan<char> format)
-#else
-        public static bool DragInt4(string label, ref int v, float v_speed, int v_min, int v_max, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -5590,7 +5110,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -5619,17 +5139,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt4(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min, int v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool DragInt4(string label, ref int v, float v_speed, int v_min, int v_max, string format, ImGuiSliderFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -5647,7 +5163,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -5675,17 +5191,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragIntRange2(ReadOnlySpan<char> label, ref int v_current_min, ref int v_current_max)
-#else
-        public static bool DragIntRange2(string label, ref int v_current_min, ref int v_current_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -5704,7 +5216,7 @@ namespace ImGuiNET
             int v_max = 0;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                format_byteCount = Util.GetUtf8ByteCount("%d");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -5735,17 +5247,13 @@ namespace ImGuiNET
                 }
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragIntRange2(ReadOnlySpan<char> label, ref int v_current_min, ref int v_current_max, float v_speed)
-#else
-        public static bool DragIntRange2(string label, ref int v_current_min, ref int v_current_max, float v_speed)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -5763,7 +5271,7 @@ namespace ImGuiNET
             int v_max = 0;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                format_byteCount = Util.GetUtf8ByteCount("%d");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -5794,17 +5302,13 @@ namespace ImGuiNET
                 }
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragIntRange2(ReadOnlySpan<char> label, ref int v_current_min, ref int v_current_max, float v_speed, int v_min)
-#else
-        public static bool DragIntRange2(string label, ref int v_current_min, ref int v_current_max, float v_speed, int v_min)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -5821,7 +5325,7 @@ namespace ImGuiNET
             int v_max = 0;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                format_byteCount = Util.GetUtf8ByteCount("%d");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -5852,17 +5356,13 @@ namespace ImGuiNET
                 }
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragIntRange2(ReadOnlySpan<char> label, ref int v_current_min, ref int v_current_max, float v_speed, int v_min, int v_max)
-#else
-        public static bool DragIntRange2(string label, ref int v_current_min, ref int v_current_max, float v_speed, int v_min, int v_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -5878,7 +5378,7 @@ namespace ImGuiNET
             else { native_label = null; }
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                format_byteCount = Util.GetUtf8ByteCount("%d");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -5909,17 +5409,13 @@ namespace ImGuiNET
                 }
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragIntRange2(ReadOnlySpan<char> label, ref int v_current_min, ref int v_current_max, float v_speed, int v_min, int v_max, ReadOnlySpan<char> format)
-#else
-        public static bool DragIntRange2(string label, ref int v_current_min, ref int v_current_max, float v_speed, int v_min, int v_max, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -5937,7 +5433,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -5970,17 +5466,13 @@ namespace ImGuiNET
                 }
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragIntRange2(ReadOnlySpan<char> label, ref int v_current_min, ref int v_current_max, float v_speed, int v_min, int v_max, ReadOnlySpan<char> format, ReadOnlySpan<char> format_max)
-#else
-        public static bool DragIntRange2(string label, ref int v_current_min, ref int v_current_max, float v_speed, int v_min, int v_max, string format, string format_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -5998,7 +5490,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -6016,7 +5508,7 @@ namespace ImGuiNET
             int format_max_byteCount = 0;
             if (format_max != null)
             {
-                format_max_byteCount = Encoding.UTF8.GetByteCount(format_max);
+                format_max_byteCount = Util.GetUtf8ByteCount(format_max);
                 if (format_max_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format_max = Util.Allocate(format_max_byteCount + 1);
@@ -6052,17 +5544,13 @@ namespace ImGuiNET
                 }
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragIntRange2(ReadOnlySpan<char> label, ref int v_current_min, ref int v_current_max, float v_speed, int v_min, int v_max, ReadOnlySpan<char> format, ReadOnlySpan<char> format_max, ImGuiSliderFlags flags)
-#else
-        public static bool DragIntRange2(string label, ref int v_current_min, ref int v_current_max, float v_speed, int v_min, int v_max, string format, string format_max, ImGuiSliderFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -6080,7 +5568,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -6098,7 +5586,7 @@ namespace ImGuiNET
             int format_max_byteCount = 0;
             if (format_max != null)
             {
-                format_max_byteCount = Encoding.UTF8.GetByteCount(format_max);
+                format_max_byteCount = Util.GetUtf8ByteCount(format_max);
                 if (format_max_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format_max = Util.Allocate(format_max_byteCount + 1);
@@ -6133,17 +5621,13 @@ namespace ImGuiNET
                 }
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragScalar(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data)
-#else
-        public static bool DragScalar(string label, ImGuiDataType data_type, IntPtr p_data)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -6170,17 +5654,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragScalar(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, float v_speed)
-#else
-        public static bool DragScalar(string label, ImGuiDataType data_type, IntPtr p_data, float v_speed)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -6206,17 +5686,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragScalar(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, float v_speed, IntPtr p_min)
-#else
-        public static bool DragScalar(string label, ImGuiDataType data_type, IntPtr p_data, float v_speed, IntPtr p_min)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -6242,17 +5718,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragScalar(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, float v_speed, IntPtr p_min, IntPtr p_max)
-#else
-        public static bool DragScalar(string label, ImGuiDataType data_type, IntPtr p_data, float v_speed, IntPtr p_min, IntPtr p_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -6278,17 +5750,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragScalar(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, float v_speed, IntPtr p_min, IntPtr p_max, ReadOnlySpan<char> format)
-#else
-        public static bool DragScalar(string label, ImGuiDataType data_type, IntPtr p_data, float v_speed, IntPtr p_min, IntPtr p_max, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -6309,7 +5777,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -6335,17 +5803,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragScalar(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, float v_speed, IntPtr p_min, IntPtr p_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool DragScalar(string label, ImGuiDataType data_type, IntPtr p_data, float v_speed, IntPtr p_min, IntPtr p_max, string format, ImGuiSliderFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -6366,7 +5830,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -6391,17 +5855,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragScalarN(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, int components)
-#else
-        public static bool DragScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -6428,17 +5888,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragScalarN(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, int components, float v_speed)
-#else
-        public static bool DragScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, float v_speed)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -6464,17 +5920,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragScalarN(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, int components, float v_speed, IntPtr p_min)
-#else
-        public static bool DragScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, float v_speed, IntPtr p_min)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -6500,17 +5952,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragScalarN(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, int components, float v_speed, IntPtr p_min, IntPtr p_max)
-#else
-        public static bool DragScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, float v_speed, IntPtr p_min, IntPtr p_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -6536,17 +5984,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragScalarN(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, int components, float v_speed, IntPtr p_min, IntPtr p_max, ReadOnlySpan<char> format)
-#else
-        public static bool DragScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, float v_speed, IntPtr p_min, IntPtr p_max, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -6567,7 +6011,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -6593,17 +6037,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragScalarN(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, int components, float v_speed, IntPtr p_min, IntPtr p_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool DragScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, float v_speed, IntPtr p_min, IntPtr p_max, string format, ImGuiSliderFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -6624,7 +6064,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -6920,17 +6360,13 @@ namespace ImGuiNET
             float ret = ImGuiNative.igGetFrameHeightWithSpacing();
             return ret;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static uint GetID(ReadOnlySpan<char> str_id)
-#else
-        public static uint GetID(string str_id)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -7202,17 +6638,13 @@ namespace ImGuiNET
         {
             ImGuiNative.igImage(user_texture_id, size, uv0, uv1, tint_col, border_col);
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ImageButton(ReadOnlySpan<char> str_id, IntPtr user_texture_id, Vector2 size)
-#else
-        public static bool ImageButton(string str_id, IntPtr user_texture_id, Vector2 size)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -7237,17 +6669,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ImageButton(ReadOnlySpan<char> str_id, IntPtr user_texture_id, Vector2 size, Vector2 uv0)
-#else
-        public static bool ImageButton(string str_id, IntPtr user_texture_id, Vector2 size, Vector2 uv0)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -7271,17 +6699,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ImageButton(ReadOnlySpan<char> str_id, IntPtr user_texture_id, Vector2 size, Vector2 uv0, Vector2 uv1)
-#else
-        public static bool ImageButton(string str_id, IntPtr user_texture_id, Vector2 size, Vector2 uv0, Vector2 uv1)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -7304,17 +6728,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ImageButton(ReadOnlySpan<char> str_id, IntPtr user_texture_id, Vector2 size, Vector2 uv0, Vector2 uv1, Vector4 bg_col)
-#else
-        public static bool ImageButton(string str_id, IntPtr user_texture_id, Vector2 size, Vector2 uv0, Vector2 uv1, Vector4 bg_col)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -7336,17 +6756,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ImageButton(ReadOnlySpan<char> str_id, IntPtr user_texture_id, Vector2 size, Vector2 uv0, Vector2 uv1, Vector4 bg_col, Vector4 tint_col)
-#else
-        public static bool ImageButton(string str_id, IntPtr user_texture_id, Vector2 size, Vector2 uv0, Vector2 uv1, Vector4 bg_col, Vector4 tint_col)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -7376,17 +6792,13 @@ namespace ImGuiNET
         {
             ImGuiNative.igIndent(indent_w);
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputDouble(ReadOnlySpan<char> label, ref double v)
-#else
-        public static bool InputDouble(string label, ref double v)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -7404,7 +6816,7 @@ namespace ImGuiNET
             double step_fast = 0.0;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.6f");
+                format_byteCount = Util.GetUtf8ByteCount("%.6f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -7431,17 +6843,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputDouble(ReadOnlySpan<char> label, ref double v, double step)
-#else
-        public static bool InputDouble(string label, ref double v, double step)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -7458,7 +6866,7 @@ namespace ImGuiNET
             double step_fast = 0.0;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.6f");
+                format_byteCount = Util.GetUtf8ByteCount("%.6f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -7485,17 +6893,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputDouble(ReadOnlySpan<char> label, ref double v, double step, double step_fast)
-#else
-        public static bool InputDouble(string label, ref double v, double step, double step_fast)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -7511,7 +6915,7 @@ namespace ImGuiNET
             else { native_label = null; }
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.6f");
+                format_byteCount = Util.GetUtf8ByteCount("%.6f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -7538,17 +6942,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputDouble(ReadOnlySpan<char> label, ref double v, double step, double step_fast, ReadOnlySpan<char> format)
-#else
-        public static bool InputDouble(string label, ref double v, double step, double step_fast, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -7566,7 +6966,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -7595,17 +6995,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputDouble(ReadOnlySpan<char> label, ref double v, double step, double step_fast, ReadOnlySpan<char> format, ImGuiInputTextFlags flags)
-#else
-        public static bool InputDouble(string label, ref double v, double step, double step_fast, string format, ImGuiInputTextFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -7623,7 +7019,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -7651,17 +7047,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputFloat(ReadOnlySpan<char> label, ref float v)
-#else
-        public static bool InputFloat(string label, ref float v)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -7679,7 +7071,7 @@ namespace ImGuiNET
             float step_fast = 0.0f;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                format_byteCount = Util.GetUtf8ByteCount("%.3f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -7706,17 +7098,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputFloat(ReadOnlySpan<char> label, ref float v, float step)
-#else
-        public static bool InputFloat(string label, ref float v, float step)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -7733,7 +7121,7 @@ namespace ImGuiNET
             float step_fast = 0.0f;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                format_byteCount = Util.GetUtf8ByteCount("%.3f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -7760,17 +7148,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputFloat(ReadOnlySpan<char> label, ref float v, float step, float step_fast)
-#else
-        public static bool InputFloat(string label, ref float v, float step, float step_fast)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -7786,7 +7170,7 @@ namespace ImGuiNET
             else { native_label = null; }
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                format_byteCount = Util.GetUtf8ByteCount("%.3f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -7813,17 +7197,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputFloat(ReadOnlySpan<char> label, ref float v, float step, float step_fast, ReadOnlySpan<char> format)
-#else
-        public static bool InputFloat(string label, ref float v, float step, float step_fast, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -7841,7 +7221,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -7870,17 +7250,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputFloat(ReadOnlySpan<char> label, ref float v, float step, float step_fast, ReadOnlySpan<char> format, ImGuiInputTextFlags flags)
-#else
-        public static bool InputFloat(string label, ref float v, float step, float step_fast, string format, ImGuiInputTextFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -7898,7 +7274,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -7926,17 +7302,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputFloat2(ReadOnlySpan<char> label, ref Vector2 v)
-#else
-        public static bool InputFloat2(string label, ref Vector2 v)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -7952,7 +7324,7 @@ namespace ImGuiNET
             else { native_label = null; }
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                format_byteCount = Util.GetUtf8ByteCount("%.3f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -7979,17 +7351,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputFloat2(ReadOnlySpan<char> label, ref Vector2 v, ReadOnlySpan<char> format)
-#else
-        public static bool InputFloat2(string label, ref Vector2 v, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -8007,7 +7375,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -8036,17 +7404,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputFloat2(ReadOnlySpan<char> label, ref Vector2 v, ReadOnlySpan<char> format, ImGuiInputTextFlags flags)
-#else
-        public static bool InputFloat2(string label, ref Vector2 v, string format, ImGuiInputTextFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -8064,7 +7428,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -8092,17 +7456,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputFloat3(ReadOnlySpan<char> label, ref Vector3 v)
-#else
-        public static bool InputFloat3(string label, ref Vector3 v)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -8118,7 +7478,7 @@ namespace ImGuiNET
             else { native_label = null; }
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                format_byteCount = Util.GetUtf8ByteCount("%.3f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -8145,17 +7505,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputFloat3(ReadOnlySpan<char> label, ref Vector3 v, ReadOnlySpan<char> format)
-#else
-        public static bool InputFloat3(string label, ref Vector3 v, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -8173,7 +7529,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -8202,17 +7558,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputFloat3(ReadOnlySpan<char> label, ref Vector3 v, ReadOnlySpan<char> format, ImGuiInputTextFlags flags)
-#else
-        public static bool InputFloat3(string label, ref Vector3 v, string format, ImGuiInputTextFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -8230,7 +7582,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -8258,17 +7610,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputFloat4(ReadOnlySpan<char> label, ref Vector4 v)
-#else
-        public static bool InputFloat4(string label, ref Vector4 v)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -8284,7 +7632,7 @@ namespace ImGuiNET
             else { native_label = null; }
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                format_byteCount = Util.GetUtf8ByteCount("%.3f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -8311,17 +7659,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputFloat4(ReadOnlySpan<char> label, ref Vector4 v, ReadOnlySpan<char> format)
-#else
-        public static bool InputFloat4(string label, ref Vector4 v, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -8339,7 +7683,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -8368,17 +7712,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputFloat4(ReadOnlySpan<char> label, ref Vector4 v, ReadOnlySpan<char> format, ImGuiInputTextFlags flags)
-#else
-        public static bool InputFloat4(string label, ref Vector4 v, string format, ImGuiInputTextFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -8396,7 +7736,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -8424,17 +7764,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputInt(ReadOnlySpan<char> label, ref int v)
-#else
-        public static bool InputInt(string label, ref int v)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -8461,17 +7797,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputInt(ReadOnlySpan<char> label, ref int v, int step)
-#else
-        public static bool InputInt(string label, ref int v, int step)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -8497,17 +7829,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputInt(ReadOnlySpan<char> label, ref int v, int step, int step_fast)
-#else
-        public static bool InputInt(string label, ref int v, int step, int step_fast)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -8532,17 +7860,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputInt(ReadOnlySpan<char> label, ref int v, int step, int step_fast, ImGuiInputTextFlags flags)
-#else
-        public static bool InputInt(string label, ref int v, int step, int step_fast, ImGuiInputTextFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -8566,17 +7890,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputInt2(ReadOnlySpan<char> label, ref int v)
-#else
-        public static bool InputInt2(string label, ref int v)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -8601,17 +7921,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputInt2(ReadOnlySpan<char> label, ref int v, ImGuiInputTextFlags flags)
-#else
-        public static bool InputInt2(string label, ref int v, ImGuiInputTextFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -8635,17 +7951,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputInt3(ReadOnlySpan<char> label, ref int v)
-#else
-        public static bool InputInt3(string label, ref int v)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -8670,17 +7982,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputInt3(ReadOnlySpan<char> label, ref int v, ImGuiInputTextFlags flags)
-#else
-        public static bool InputInt3(string label, ref int v, ImGuiInputTextFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -8704,17 +8012,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputInt4(ReadOnlySpan<char> label, ref int v)
-#else
-        public static bool InputInt4(string label, ref int v)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -8739,17 +8043,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputInt4(ReadOnlySpan<char> label, ref int v, ImGuiInputTextFlags flags)
-#else
-        public static bool InputInt4(string label, ref int v, ImGuiInputTextFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -8773,17 +8073,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputScalar(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data)
-#else
-        public static bool InputScalar(string label, ImGuiDataType data_type, IntPtr p_data)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -8809,17 +8105,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputScalar(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_step)
-#else
-        public static bool InputScalar(string label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_step)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -8845,17 +8137,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputScalar(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_step, IntPtr p_step_fast)
-#else
-        public static bool InputScalar(string label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_step, IntPtr p_step_fast)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -8881,17 +8169,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputScalar(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_step, IntPtr p_step_fast, ReadOnlySpan<char> format)
-#else
-        public static bool InputScalar(string label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_step, IntPtr p_step_fast, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -8912,7 +8196,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -8938,17 +8222,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputScalar(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_step, IntPtr p_step_fast, ReadOnlySpan<char> format, ImGuiInputTextFlags flags)
-#else
-        public static bool InputScalar(string label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_step, IntPtr p_step_fast, string format, ImGuiInputTextFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -8969,7 +8249,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -8994,17 +8274,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputScalarN(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, int components)
-#else
-        public static bool InputScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -9030,17 +8306,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputScalarN(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_step)
-#else
-        public static bool InputScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_step)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -9066,17 +8338,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputScalarN(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_step, IntPtr p_step_fast)
-#else
-        public static bool InputScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_step, IntPtr p_step_fast)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -9102,17 +8370,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputScalarN(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_step, IntPtr p_step_fast, ReadOnlySpan<char> format)
-#else
-        public static bool InputScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_step, IntPtr p_step_fast, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -9133,7 +8397,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -9159,17 +8423,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputScalarN(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_step, IntPtr p_step_fast, ReadOnlySpan<char> format, ImGuiInputTextFlags flags)
-#else
-        public static bool InputScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_step, IntPtr p_step_fast, string format, ImGuiInputTextFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -9190,7 +8450,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -9215,17 +8475,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InvisibleButton(ReadOnlySpan<char> str_id, Vector2 size)
-#else
-        public static bool InvisibleButton(string str_id, Vector2 size)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -9247,17 +8503,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InvisibleButton(ReadOnlySpan<char> str_id, Vector2 size, ImGuiButtonFlags flags)
-#else
-        public static bool InvisibleButton(string str_id, Vector2 size, ImGuiButtonFlags flags)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -9446,17 +8698,13 @@ namespace ImGuiNET
             byte ret = ImGuiNative.igIsMouseReleased_Nil(button);
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool IsPopupOpen(ReadOnlySpan<char> str_id)
-#else
-        public static bool IsPopupOpen(string str_id)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -9478,17 +8726,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool IsPopupOpen(ReadOnlySpan<char> str_id, ImGuiPopupFlags flags)
-#else
-        public static bool IsPopupOpen(string str_id, ImGuiPopupFlags flags)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -9556,17 +8800,13 @@ namespace ImGuiNET
             byte ret = ImGuiNative.igIsWindowHovered(flags);
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void LabelText(ReadOnlySpan<char> label, ReadOnlySpan<char> fmt)
-#else
-        public static void LabelText(string label, string fmt)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -9584,7 +8824,7 @@ namespace ImGuiNET
             int fmt_byteCount = 0;
             if (fmt != null)
             {
-                fmt_byteCount = Encoding.UTF8.GetByteCount(fmt);
+                fmt_byteCount = Util.GetUtf8ByteCount(fmt);
                 if (fmt_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_fmt = Util.Allocate(fmt_byteCount + 1);
@@ -9608,17 +8848,13 @@ namespace ImGuiNET
                 Util.Free(native_fmt);
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ListBox(ReadOnlySpan<char> label, ref int current_item, string[] items, int items_count)
-#else
-        public static bool ListBox(string label, ref int current_item, string[] items, int items_count)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -9637,7 +8873,7 @@ namespace ImGuiNET
             for (int i = 0; i < items.Length; i++)
             {
                 string s = items[i];
-                items_byteCounts[i] = Encoding.UTF8.GetByteCount(s);
+                items_byteCounts[i] = Util.GetUtf8ByteCount(s);
                 items_byteCount += items_byteCounts[i] + 1;
             }
             byte* native_items_data = stackalloc byte[items_byteCount];
@@ -9670,17 +8906,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ListBox(ReadOnlySpan<char> label, ref int current_item, string[] items, int items_count, int height_in_items)
-#else
-        public static bool ListBox(string label, ref int current_item, string[] items, int items_count, int height_in_items)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -9699,7 +8931,7 @@ namespace ImGuiNET
             for (int i = 0; i < items.Length; i++)
             {
                 string s = items[i];
-                items_byteCounts[i] = Encoding.UTF8.GetByteCount(s);
+                items_byteCounts[i] = Util.GetUtf8ByteCount(s);
                 items_byteCount += items_byteCounts[i] + 1;
             }
             byte* native_items_data = stackalloc byte[items_byteCount];
@@ -9731,17 +8963,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void LoadIniSettingsFromDisk(ReadOnlySpan<char> ini_filename)
-#else
-        public static void LoadIniSettingsFromDisk(string ini_filename)
-#endif
         {
             byte* native_ini_filename;
             int ini_filename_byteCount = 0;
             if (ini_filename != null)
             {
-                ini_filename_byteCount = Encoding.UTF8.GetByteCount(ini_filename);
+                ini_filename_byteCount = Util.GetUtf8ByteCount(ini_filename);
                 if (ini_filename_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_ini_filename = Util.Allocate(ini_filename_byteCount + 1);
@@ -9761,17 +8989,13 @@ namespace ImGuiNET
                 Util.Free(native_ini_filename);
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void LoadIniSettingsFromMemory(ReadOnlySpan<char> ini_data)
-#else
-        public static void LoadIniSettingsFromMemory(string ini_data)
-#endif
         {
             byte* native_ini_data;
             int ini_data_byteCount = 0;
             if (ini_data != null)
             {
-                ini_data_byteCount = Encoding.UTF8.GetByteCount(ini_data);
+                ini_data_byteCount = Util.GetUtf8ByteCount(ini_data);
                 if (ini_data_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_ini_data = Util.Allocate(ini_data_byteCount + 1);
@@ -9792,17 +9016,13 @@ namespace ImGuiNET
                 Util.Free(native_ini_data);
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void LoadIniSettingsFromMemory(ReadOnlySpan<char> ini_data, uint ini_size)
-#else
-        public static void LoadIniSettingsFromMemory(string ini_data, uint ini_size)
-#endif
         {
             byte* native_ini_data;
             int ini_data_byteCount = 0;
             if (ini_data != null)
             {
-                ini_data_byteCount = Encoding.UTF8.GetByteCount(ini_data);
+                ini_data_byteCount = Util.GetUtf8ByteCount(ini_data);
                 if (ini_data_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_ini_data = Util.Allocate(ini_data_byteCount + 1);
@@ -9830,17 +9050,13 @@ namespace ImGuiNET
         {
             ImGuiNative.igLogFinish();
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void LogText(ReadOnlySpan<char> fmt)
-#else
-        public static void LogText(string fmt)
-#endif
         {
             byte* native_fmt;
             int fmt_byteCount = 0;
             if (fmt != null)
             {
-                fmt_byteCount = Encoding.UTF8.GetByteCount(fmt);
+                fmt_byteCount = Util.GetUtf8ByteCount(fmt);
                 if (fmt_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_fmt = Util.Allocate(fmt_byteCount + 1);
@@ -9880,17 +9096,13 @@ namespace ImGuiNET
             byte* native_filename = null;
             ImGuiNative.igLogToFile(auto_open_depth, native_filename);
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void LogToFile(int auto_open_depth, ReadOnlySpan<char> filename)
-#else
-        public static void LogToFile(int auto_open_depth, string filename)
-#endif
         {
             byte* native_filename;
             int filename_byteCount = 0;
             if (filename != null)
             {
-                filename_byteCount = Encoding.UTF8.GetByteCount(filename);
+                filename_byteCount = Util.GetUtf8ByteCount(filename);
                 if (filename_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_filename = Util.Allocate(filename_byteCount + 1);
@@ -9929,17 +9141,13 @@ namespace ImGuiNET
             void* native_ptr = (void*)ptr.ToPointer();
             ImGuiNative.igMemFree(native_ptr);
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool MenuItem(ReadOnlySpan<char> label)
-#else
-        public static bool MenuItem(string label)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -9963,17 +9171,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool MenuItem(ReadOnlySpan<char> label, ReadOnlySpan<char> shortcut)
-#else
-        public static bool MenuItem(string label, string shortcut)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -9991,7 +9195,7 @@ namespace ImGuiNET
             int shortcut_byteCount = 0;
             if (shortcut != null)
             {
-                shortcut_byteCount = Encoding.UTF8.GetByteCount(shortcut);
+                shortcut_byteCount = Util.GetUtf8ByteCount(shortcut);
                 if (shortcut_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_shortcut = Util.Allocate(shortcut_byteCount + 1);
@@ -10018,17 +9222,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool MenuItem(ReadOnlySpan<char> label, ReadOnlySpan<char> shortcut, bool selected)
-#else
-        public static bool MenuItem(string label, string shortcut, bool selected)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -10046,7 +9246,7 @@ namespace ImGuiNET
             int shortcut_byteCount = 0;
             if (shortcut != null)
             {
-                shortcut_byteCount = Encoding.UTF8.GetByteCount(shortcut);
+                shortcut_byteCount = Util.GetUtf8ByteCount(shortcut);
                 if (shortcut_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_shortcut = Util.Allocate(shortcut_byteCount + 1);
@@ -10073,17 +9273,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool MenuItem(ReadOnlySpan<char> label, ReadOnlySpan<char> shortcut, bool selected, bool enabled)
-#else
-        public static bool MenuItem(string label, string shortcut, bool selected, bool enabled)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -10101,7 +9297,7 @@ namespace ImGuiNET
             int shortcut_byteCount = 0;
             if (shortcut != null)
             {
-                shortcut_byteCount = Encoding.UTF8.GetByteCount(shortcut);
+                shortcut_byteCount = Util.GetUtf8ByteCount(shortcut);
                 if (shortcut_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_shortcut = Util.Allocate(shortcut_byteCount + 1);
@@ -10128,17 +9324,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool MenuItem(ReadOnlySpan<char> label, ReadOnlySpan<char> shortcut, ref bool p_selected)
-#else
-        public static bool MenuItem(string label, string shortcut, ref bool p_selected)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -10156,7 +9348,7 @@ namespace ImGuiNET
             int shortcut_byteCount = 0;
             if (shortcut != null)
             {
-                shortcut_byteCount = Encoding.UTF8.GetByteCount(shortcut);
+                shortcut_byteCount = Util.GetUtf8ByteCount(shortcut);
                 if (shortcut_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_shortcut = Util.Allocate(shortcut_byteCount + 1);
@@ -10185,17 +9377,13 @@ namespace ImGuiNET
             p_selected = native_p_selected_val != 0;
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool MenuItem(ReadOnlySpan<char> label, ReadOnlySpan<char> shortcut, ref bool p_selected, bool enabled)
-#else
-        public static bool MenuItem(string label, string shortcut, ref bool p_selected, bool enabled)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -10213,7 +9401,7 @@ namespace ImGuiNET
             int shortcut_byteCount = 0;
             if (shortcut != null)
             {
-                shortcut_byteCount = Encoding.UTF8.GetByteCount(shortcut);
+                shortcut_byteCount = Util.GetUtf8ByteCount(shortcut);
                 if (shortcut_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_shortcut = Util.Allocate(shortcut_byteCount + 1);
@@ -10254,17 +9442,13 @@ namespace ImGuiNET
         {
             ImGuiNative.igNextColumn();
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void OpenPopup(ReadOnlySpan<char> str_id)
-#else
-        public static void OpenPopup(string str_id)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -10285,17 +9469,13 @@ namespace ImGuiNET
                 Util.Free(native_str_id);
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void OpenPopup(ReadOnlySpan<char> str_id, ImGuiPopupFlags popup_flags)
-#else
-        public static void OpenPopup(string str_id, ImGuiPopupFlags popup_flags)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -10330,17 +9510,13 @@ namespace ImGuiNET
             ImGuiPopupFlags popup_flags = (ImGuiPopupFlags)1;
             ImGuiNative.igOpenPopupOnItemClick(native_str_id, popup_flags);
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void OpenPopupOnItemClick(ReadOnlySpan<char> str_id)
-#else
-        public static void OpenPopupOnItemClick(string str_id)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -10361,17 +9537,13 @@ namespace ImGuiNET
                 Util.Free(native_str_id);
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void OpenPopupOnItemClick(ReadOnlySpan<char> str_id, ImGuiPopupFlags popup_flags)
-#else
-        public static void OpenPopupOnItemClick(string str_id, ImGuiPopupFlags popup_flags)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -10391,17 +9563,13 @@ namespace ImGuiNET
                 Util.Free(native_str_id);
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void PlotHistogram(ReadOnlySpan<char> label, ref float values, int values_count)
-#else
-        public static void PlotHistogram(string label, ref float values, int values_count)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -10430,17 +9598,13 @@ namespace ImGuiNET
                 }
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void PlotHistogram(ReadOnlySpan<char> label, ref float values, int values_count, int values_offset)
-#else
-        public static void PlotHistogram(string label, ref float values, int values_count, int values_offset)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -10468,17 +9632,13 @@ namespace ImGuiNET
                 }
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void PlotHistogram(ReadOnlySpan<char> label, ref float values, int values_count, int values_offset, ReadOnlySpan<char> overlay_text)
-#else
-        public static void PlotHistogram(string label, ref float values, int values_count, int values_offset, string overlay_text)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -10496,7 +9656,7 @@ namespace ImGuiNET
             int overlay_text_byteCount = 0;
             if (overlay_text != null)
             {
-                overlay_text_byteCount = Encoding.UTF8.GetByteCount(overlay_text);
+                overlay_text_byteCount = Util.GetUtf8ByteCount(overlay_text);
                 if (overlay_text_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_overlay_text = Util.Allocate(overlay_text_byteCount + 1);
@@ -10527,17 +9687,13 @@ namespace ImGuiNET
                 }
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void PlotHistogram(ReadOnlySpan<char> label, ref float values, int values_count, int values_offset, ReadOnlySpan<char> overlay_text, float scale_min)
-#else
-        public static void PlotHistogram(string label, ref float values, int values_count, int values_offset, string overlay_text, float scale_min)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -10555,7 +9711,7 @@ namespace ImGuiNET
             int overlay_text_byteCount = 0;
             if (overlay_text != null)
             {
-                overlay_text_byteCount = Encoding.UTF8.GetByteCount(overlay_text);
+                overlay_text_byteCount = Util.GetUtf8ByteCount(overlay_text);
                 if (overlay_text_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_overlay_text = Util.Allocate(overlay_text_byteCount + 1);
@@ -10585,17 +9741,13 @@ namespace ImGuiNET
                 }
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void PlotHistogram(ReadOnlySpan<char> label, ref float values, int values_count, int values_offset, ReadOnlySpan<char> overlay_text, float scale_min, float scale_max)
-#else
-        public static void PlotHistogram(string label, ref float values, int values_count, int values_offset, string overlay_text, float scale_min, float scale_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -10613,7 +9765,7 @@ namespace ImGuiNET
             int overlay_text_byteCount = 0;
             if (overlay_text != null)
             {
-                overlay_text_byteCount = Encoding.UTF8.GetByteCount(overlay_text);
+                overlay_text_byteCount = Util.GetUtf8ByteCount(overlay_text);
                 if (overlay_text_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_overlay_text = Util.Allocate(overlay_text_byteCount + 1);
@@ -10642,17 +9794,13 @@ namespace ImGuiNET
                 }
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void PlotHistogram(ReadOnlySpan<char> label, ref float values, int values_count, int values_offset, ReadOnlySpan<char> overlay_text, float scale_min, float scale_max, Vector2 graph_size)
-#else
-        public static void PlotHistogram(string label, ref float values, int values_count, int values_offset, string overlay_text, float scale_min, float scale_max, Vector2 graph_size)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -10670,7 +9818,7 @@ namespace ImGuiNET
             int overlay_text_byteCount = 0;
             if (overlay_text != null)
             {
-                overlay_text_byteCount = Encoding.UTF8.GetByteCount(overlay_text);
+                overlay_text_byteCount = Util.GetUtf8ByteCount(overlay_text);
                 if (overlay_text_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_overlay_text = Util.Allocate(overlay_text_byteCount + 1);
@@ -10698,17 +9846,13 @@ namespace ImGuiNET
                 }
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void PlotHistogram(ReadOnlySpan<char> label, ref float values, int values_count, int values_offset, ReadOnlySpan<char> overlay_text, float scale_min, float scale_max, Vector2 graph_size, int stride)
-#else
-        public static void PlotHistogram(string label, ref float values, int values_count, int values_offset, string overlay_text, float scale_min, float scale_max, Vector2 graph_size, int stride)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -10726,7 +9870,7 @@ namespace ImGuiNET
             int overlay_text_byteCount = 0;
             if (overlay_text != null)
             {
-                overlay_text_byteCount = Encoding.UTF8.GetByteCount(overlay_text);
+                overlay_text_byteCount = Util.GetUtf8ByteCount(overlay_text);
                 if (overlay_text_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_overlay_text = Util.Allocate(overlay_text_byteCount + 1);
@@ -10753,17 +9897,13 @@ namespace ImGuiNET
                 }
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void PlotLines(ReadOnlySpan<char> label, ref float values, int values_count)
-#else
-        public static void PlotLines(string label, ref float values, int values_count)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -10792,17 +9932,13 @@ namespace ImGuiNET
                 }
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void PlotLines(ReadOnlySpan<char> label, ref float values, int values_count, int values_offset)
-#else
-        public static void PlotLines(string label, ref float values, int values_count, int values_offset)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -10830,17 +9966,13 @@ namespace ImGuiNET
                 }
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void PlotLines(ReadOnlySpan<char> label, ref float values, int values_count, int values_offset, ReadOnlySpan<char> overlay_text)
-#else
-        public static void PlotLines(string label, ref float values, int values_count, int values_offset, string overlay_text)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -10858,7 +9990,7 @@ namespace ImGuiNET
             int overlay_text_byteCount = 0;
             if (overlay_text != null)
             {
-                overlay_text_byteCount = Encoding.UTF8.GetByteCount(overlay_text);
+                overlay_text_byteCount = Util.GetUtf8ByteCount(overlay_text);
                 if (overlay_text_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_overlay_text = Util.Allocate(overlay_text_byteCount + 1);
@@ -10889,17 +10021,13 @@ namespace ImGuiNET
                 }
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void PlotLines(ReadOnlySpan<char> label, ref float values, int values_count, int values_offset, ReadOnlySpan<char> overlay_text, float scale_min)
-#else
-        public static void PlotLines(string label, ref float values, int values_count, int values_offset, string overlay_text, float scale_min)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -10917,7 +10045,7 @@ namespace ImGuiNET
             int overlay_text_byteCount = 0;
             if (overlay_text != null)
             {
-                overlay_text_byteCount = Encoding.UTF8.GetByteCount(overlay_text);
+                overlay_text_byteCount = Util.GetUtf8ByteCount(overlay_text);
                 if (overlay_text_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_overlay_text = Util.Allocate(overlay_text_byteCount + 1);
@@ -10947,17 +10075,13 @@ namespace ImGuiNET
                 }
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void PlotLines(ReadOnlySpan<char> label, ref float values, int values_count, int values_offset, ReadOnlySpan<char> overlay_text, float scale_min, float scale_max)
-#else
-        public static void PlotLines(string label, ref float values, int values_count, int values_offset, string overlay_text, float scale_min, float scale_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -10975,7 +10099,7 @@ namespace ImGuiNET
             int overlay_text_byteCount = 0;
             if (overlay_text != null)
             {
-                overlay_text_byteCount = Encoding.UTF8.GetByteCount(overlay_text);
+                overlay_text_byteCount = Util.GetUtf8ByteCount(overlay_text);
                 if (overlay_text_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_overlay_text = Util.Allocate(overlay_text_byteCount + 1);
@@ -11004,17 +10128,13 @@ namespace ImGuiNET
                 }
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void PlotLines(ReadOnlySpan<char> label, ref float values, int values_count, int values_offset, ReadOnlySpan<char> overlay_text, float scale_min, float scale_max, Vector2 graph_size)
-#else
-        public static void PlotLines(string label, ref float values, int values_count, int values_offset, string overlay_text, float scale_min, float scale_max, Vector2 graph_size)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -11032,7 +10152,7 @@ namespace ImGuiNET
             int overlay_text_byteCount = 0;
             if (overlay_text != null)
             {
-                overlay_text_byteCount = Encoding.UTF8.GetByteCount(overlay_text);
+                overlay_text_byteCount = Util.GetUtf8ByteCount(overlay_text);
                 if (overlay_text_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_overlay_text = Util.Allocate(overlay_text_byteCount + 1);
@@ -11060,17 +10180,13 @@ namespace ImGuiNET
                 }
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void PlotLines(ReadOnlySpan<char> label, ref float values, int values_count, int values_offset, ReadOnlySpan<char> overlay_text, float scale_min, float scale_max, Vector2 graph_size, int stride)
-#else
-        public static void PlotLines(string label, ref float values, int values_count, int values_offset, string overlay_text, float scale_min, float scale_max, Vector2 graph_size, int stride)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -11088,7 +10204,7 @@ namespace ImGuiNET
             int overlay_text_byteCount = 0;
             if (overlay_text != null)
             {
-                overlay_text_byteCount = Encoding.UTF8.GetByteCount(overlay_text);
+                overlay_text_byteCount = Util.GetUtf8ByteCount(overlay_text);
                 if (overlay_text_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_overlay_text = Util.Allocate(overlay_text_byteCount + 1);
@@ -11172,17 +10288,13 @@ namespace ImGuiNET
             byte* native_overlay = null;
             ImGuiNative.igProgressBar(fraction, size_arg, native_overlay);
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void ProgressBar(float fraction, Vector2 size_arg, ReadOnlySpan<char> overlay)
-#else
-        public static void ProgressBar(float fraction, Vector2 size_arg, string overlay)
-#endif
         {
             byte* native_overlay;
             int overlay_byteCount = 0;
             if (overlay != null)
             {
-                overlay_byteCount = Encoding.UTF8.GetByteCount(overlay);
+                overlay_byteCount = Util.GetUtf8ByteCount(overlay);
                 if (overlay_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_overlay = Util.Allocate(overlay_byteCount + 1);
@@ -11217,17 +10329,13 @@ namespace ImGuiNET
             ImFont* native_font = font.NativePtr;
             ImGuiNative.igPushFont(native_font);
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void PushID(ReadOnlySpan<char> str_id)
-#else
-        public static void PushID(string str_id)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -11290,17 +10398,13 @@ namespace ImGuiNET
         {
             ImGuiNative.igPushTextWrapPos(wrap_local_pos_x);
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool RadioButton(ReadOnlySpan<char> label, bool active)
-#else
-        public static bool RadioButton(string label, bool active)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -11322,17 +10426,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool RadioButton(ReadOnlySpan<char> label, ref int v, int v_button)
-#else
-        public static bool RadioButton(string label, ref int v, int v_button)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -11402,17 +10502,13 @@ namespace ImGuiNET
         {
             ImGuiNative.igSameLine(offset_from_start_x, spacing);
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void SaveIniSettingsToDisk(ReadOnlySpan<char> ini_filename)
-#else
-        public static void SaveIniSettingsToDisk(string ini_filename)
-#endif
         {
             byte* native_ini_filename;
             int ini_filename_byteCount = 0;
             if (ini_filename != null)
             {
-                ini_filename_byteCount = Encoding.UTF8.GetByteCount(ini_filename);
+                ini_filename_byteCount = Util.GetUtf8ByteCount(ini_filename);
                 if (ini_filename_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_ini_filename = Util.Allocate(ini_filename_byteCount + 1);
@@ -11446,17 +10542,13 @@ namespace ImGuiNET
                 return Util.StringFromPtr(ret);
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Selectable(ReadOnlySpan<char> label)
-#else
-        public static bool Selectable(string label)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -11480,17 +10572,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Selectable(ReadOnlySpan<char> label, bool selected)
-#else
-        public static bool Selectable(string label, bool selected)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -11514,17 +10602,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Selectable(ReadOnlySpan<char> label, bool selected, ImGuiSelectableFlags flags)
-#else
-        public static bool Selectable(string label, bool selected, ImGuiSelectableFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -11547,17 +10631,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Selectable(ReadOnlySpan<char> label, bool selected, ImGuiSelectableFlags flags, Vector2 size)
-#else
-        public static bool Selectable(string label, bool selected, ImGuiSelectableFlags flags, Vector2 size)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -11579,17 +10659,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Selectable(ReadOnlySpan<char> label, ref bool p_selected)
-#else
-        public static bool Selectable(string label, ref bool p_selected)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -11615,17 +10691,13 @@ namespace ImGuiNET
             p_selected = native_p_selected_val != 0;
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Selectable(ReadOnlySpan<char> label, ref bool p_selected, ImGuiSelectableFlags flags)
-#else
-        public static bool Selectable(string label, ref bool p_selected, ImGuiSelectableFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -11650,17 +10722,13 @@ namespace ImGuiNET
             p_selected = native_p_selected_val != 0;
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Selectable(ReadOnlySpan<char> label, ref bool p_selected, ImGuiSelectableFlags flags, Vector2 size)
-#else
-        public static bool Selectable(string label, ref bool p_selected, ImGuiSelectableFlags flags, Vector2 size)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -11688,17 +10756,13 @@ namespace ImGuiNET
         {
             ImGuiNative.igSeparator();
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void SeparatorText(ReadOnlySpan<char> label)
-#else
-        public static void SeparatorText(string label)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -11728,17 +10792,13 @@ namespace ImGuiNET
             void* native_user_data = (void*)user_data.ToPointer();
             ImGuiNative.igSetAllocatorFunctions(alloc_func, free_func, native_user_data);
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void SetClipboardText(ReadOnlySpan<char> text)
-#else
-        public static void SetClipboardText(string text)
-#endif
         {
             byte* native_text;
             int text_byteCount = 0;
             if (text != null)
             {
-                text_byteCount = Encoding.UTF8.GetByteCount(text);
+                text_byteCount = Util.GetUtf8ByteCount(text);
                 if (text_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_text = Util.Allocate(text_byteCount + 1);
@@ -11790,17 +10850,13 @@ namespace ImGuiNET
         {
             ImGuiNative.igSetCursorScreenPos(pos);
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SetDragDropPayload(ReadOnlySpan<char> type, IntPtr data, uint sz)
-#else
-        public static bool SetDragDropPayload(string type, IntPtr data, uint sz)
-#endif
         {
             byte* native_type;
             int type_byteCount = 0;
             if (type != null)
             {
-                type_byteCount = Encoding.UTF8.GetByteCount(type);
+                type_byteCount = Util.GetUtf8ByteCount(type);
                 if (type_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_type = Util.Allocate(type_byteCount + 1);
@@ -11823,17 +10879,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SetDragDropPayload(ReadOnlySpan<char> type, IntPtr data, uint sz, ImGuiCond cond)
-#else
-        public static bool SetDragDropPayload(string type, IntPtr data, uint sz, ImGuiCond cond)
-#endif
         {
             byte* native_type;
             int type_byteCount = 0;
             if (type != null)
             {
-                type_byteCount = Encoding.UTF8.GetByteCount(type);
+                type_byteCount = Util.GetUtf8ByteCount(type);
                 if (type_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_type = Util.Allocate(type_byteCount + 1);
@@ -12035,17 +11087,13 @@ namespace ImGuiNET
             ImGuiStorage* native_storage = storage.NativePtr;
             ImGuiNative.igSetStateStorage(native_storage);
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void SetTabItemClosed(ReadOnlySpan<char> tab_or_docked_window_label)
-#else
-        public static void SetTabItemClosed(string tab_or_docked_window_label)
-#endif
         {
             byte* native_tab_or_docked_window_label;
             int tab_or_docked_window_label_byteCount = 0;
             if (tab_or_docked_window_label != null)
             {
-                tab_or_docked_window_label_byteCount = Encoding.UTF8.GetByteCount(tab_or_docked_window_label);
+                tab_or_docked_window_label_byteCount = Util.GetUtf8ByteCount(tab_or_docked_window_label);
                 if (tab_or_docked_window_label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_tab_or_docked_window_label = Util.Allocate(tab_or_docked_window_label_byteCount + 1);
@@ -12065,17 +11113,13 @@ namespace ImGuiNET
                 Util.Free(native_tab_or_docked_window_label);
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void SetTooltip(ReadOnlySpan<char> fmt)
-#else
-        public static void SetTooltip(string fmt)
-#endif
         {
             byte* native_fmt;
             int fmt_byteCount = 0;
             if (fmt != null)
             {
-                fmt_byteCount = Encoding.UTF8.GetByteCount(fmt);
+                fmt_byteCount = Util.GetUtf8ByteCount(fmt);
                 if (fmt_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_fmt = Util.Allocate(fmt_byteCount + 1);
@@ -12106,17 +11150,13 @@ namespace ImGuiNET
             byte native_collapsed = collapsed ? (byte)1 : (byte)0;
             ImGuiNative.igSetWindowCollapsed_Bool(native_collapsed, cond);
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void SetWindowCollapsed(ReadOnlySpan<char> name, bool collapsed)
-#else
-        public static void SetWindowCollapsed(string name, bool collapsed)
-#endif
         {
             byte* native_name;
             int name_byteCount = 0;
             if (name != null)
             {
-                name_byteCount = Encoding.UTF8.GetByteCount(name);
+                name_byteCount = Util.GetUtf8ByteCount(name);
                 if (name_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_name = Util.Allocate(name_byteCount + 1);
@@ -12138,17 +11178,13 @@ namespace ImGuiNET
                 Util.Free(native_name);
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void SetWindowCollapsed(ReadOnlySpan<char> name, bool collapsed, ImGuiCond cond)
-#else
-        public static void SetWindowCollapsed(string name, bool collapsed, ImGuiCond cond)
-#endif
         {
             byte* native_name;
             int name_byteCount = 0;
             if (name != null)
             {
-                name_byteCount = Encoding.UTF8.GetByteCount(name);
+                name_byteCount = Util.GetUtf8ByteCount(name);
                 if (name_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_name = Util.Allocate(name_byteCount + 1);
@@ -12173,17 +11209,13 @@ namespace ImGuiNET
         {
             ImGuiNative.igSetWindowFocus_Nil();
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void SetWindowFocus(ReadOnlySpan<char> name)
-#else
-        public static void SetWindowFocus(string name)
-#endif
         {
             byte* native_name;
             int name_byteCount = 0;
             if (name != null)
             {
-                name_byteCount = Encoding.UTF8.GetByteCount(name);
+                name_byteCount = Util.GetUtf8ByteCount(name);
                 if (name_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_name = Util.Allocate(name_byteCount + 1);
@@ -12216,17 +11248,13 @@ namespace ImGuiNET
         {
             ImGuiNative.igSetWindowPos_Vec2(pos, cond);
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void SetWindowPos(ReadOnlySpan<char> name, Vector2 pos)
-#else
-        public static void SetWindowPos(string name, Vector2 pos)
-#endif
         {
             byte* native_name;
             int name_byteCount = 0;
             if (name != null)
             {
-                name_byteCount = Encoding.UTF8.GetByteCount(name);
+                name_byteCount = Util.GetUtf8ByteCount(name);
                 if (name_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_name = Util.Allocate(name_byteCount + 1);
@@ -12247,17 +11275,13 @@ namespace ImGuiNET
                 Util.Free(native_name);
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void SetWindowPos(ReadOnlySpan<char> name, Vector2 pos, ImGuiCond cond)
-#else
-        public static void SetWindowPos(string name, Vector2 pos, ImGuiCond cond)
-#endif
         {
             byte* native_name;
             int name_byteCount = 0;
             if (name != null)
             {
-                name_byteCount = Encoding.UTF8.GetByteCount(name);
+                name_byteCount = Util.GetUtf8ByteCount(name);
                 if (name_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_name = Util.Allocate(name_byteCount + 1);
@@ -12286,17 +11310,13 @@ namespace ImGuiNET
         {
             ImGuiNative.igSetWindowSize_Vec2(size, cond);
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void SetWindowSize(ReadOnlySpan<char> name, Vector2 size)
-#else
-        public static void SetWindowSize(string name, Vector2 size)
-#endif
         {
             byte* native_name;
             int name_byteCount = 0;
             if (name != null)
             {
-                name_byteCount = Encoding.UTF8.GetByteCount(name);
+                name_byteCount = Util.GetUtf8ByteCount(name);
                 if (name_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_name = Util.Allocate(name_byteCount + 1);
@@ -12317,17 +11337,13 @@ namespace ImGuiNET
                 Util.Free(native_name);
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void SetWindowSize(ReadOnlySpan<char> name, Vector2 size, ImGuiCond cond)
-#else
-        public static void SetWindowSize(string name, Vector2 size, ImGuiCond cond)
-#endif
         {
             byte* native_name;
             int name_byteCount = 0;
             if (name != null)
             {
-                name_byteCount = Encoding.UTF8.GetByteCount(name);
+                name_byteCount = Util.GetUtf8ByteCount(name);
                 if (name_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_name = Util.Allocate(name_byteCount + 1);
@@ -12383,17 +11399,13 @@ namespace ImGuiNET
             ImGuiNative.igShowDemoWindow(native_p_open);
             p_open = native_p_open_val != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void ShowFontSelector(ReadOnlySpan<char> label)
-#else
-        public static void ShowFontSelector(string label)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -12447,17 +11459,13 @@ namespace ImGuiNET
             ImGuiStyle* native_ref = @ref.NativePtr;
             ImGuiNative.igShowStyleEditor(native_ref);
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ShowStyleSelector(ReadOnlySpan<char> label)
-#else
-        public static bool ShowStyleSelector(string label)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -12482,17 +11490,13 @@ namespace ImGuiNET
         {
             ImGuiNative.igShowUserGuide();
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderAngle(ReadOnlySpan<char> label, ref float v_rad)
-#else
-        public static bool SliderAngle(string label, ref float v_rad)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -12510,7 +11514,7 @@ namespace ImGuiNET
             float v_degrees_max = +360.0f;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.0f deg");
+                format_byteCount = Util.GetUtf8ByteCount("%.0f deg");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -12537,17 +11541,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderAngle(ReadOnlySpan<char> label, ref float v_rad, float v_degrees_min)
-#else
-        public static bool SliderAngle(string label, ref float v_rad, float v_degrees_min)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -12564,7 +11564,7 @@ namespace ImGuiNET
             float v_degrees_max = +360.0f;
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.0f deg");
+                format_byteCount = Util.GetUtf8ByteCount("%.0f deg");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -12591,17 +11591,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderAngle(ReadOnlySpan<char> label, ref float v_rad, float v_degrees_min, float v_degrees_max)
-#else
-        public static bool SliderAngle(string label, ref float v_rad, float v_degrees_min, float v_degrees_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -12617,7 +11613,7 @@ namespace ImGuiNET
             else { native_label = null; }
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.0f deg");
+                format_byteCount = Util.GetUtf8ByteCount("%.0f deg");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -12644,17 +11640,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderAngle(ReadOnlySpan<char> label, ref float v_rad, float v_degrees_min, float v_degrees_max, ReadOnlySpan<char> format)
-#else
-        public static bool SliderAngle(string label, ref float v_rad, float v_degrees_min, float v_degrees_max, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -12672,7 +11664,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -12701,17 +11693,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderAngle(ReadOnlySpan<char> label, ref float v_rad, float v_degrees_min, float v_degrees_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool SliderAngle(string label, ref float v_rad, float v_degrees_min, float v_degrees_max, string format, ImGuiSliderFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -12729,7 +11717,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -12757,17 +11745,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderFloat(ReadOnlySpan<char> label, ref float v, float v_min, float v_max)
-#else
-        public static bool SliderFloat(string label, ref float v, float v_min, float v_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -12783,7 +11767,7 @@ namespace ImGuiNET
             else { native_label = null; }
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                format_byteCount = Util.GetUtf8ByteCount("%.3f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -12810,17 +11794,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderFloat(ReadOnlySpan<char> label, ref float v, float v_min, float v_max, ReadOnlySpan<char> format)
-#else
-        public static bool SliderFloat(string label, ref float v, float v_min, float v_max, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -12838,7 +11818,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -12867,17 +11847,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderFloat(ReadOnlySpan<char> label, ref float v, float v_min, float v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool SliderFloat(string label, ref float v, float v_min, float v_max, string format, ImGuiSliderFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -12895,7 +11871,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -12923,17 +11899,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderFloat2(ReadOnlySpan<char> label, ref Vector2 v, float v_min, float v_max)
-#else
-        public static bool SliderFloat2(string label, ref Vector2 v, float v_min, float v_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -12949,7 +11921,7 @@ namespace ImGuiNET
             else { native_label = null; }
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                format_byteCount = Util.GetUtf8ByteCount("%.3f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -12976,17 +11948,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderFloat2(ReadOnlySpan<char> label, ref Vector2 v, float v_min, float v_max, ReadOnlySpan<char> format)
-#else
-        public static bool SliderFloat2(string label, ref Vector2 v, float v_min, float v_max, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -13004,7 +11972,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -13033,17 +12001,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderFloat2(ReadOnlySpan<char> label, ref Vector2 v, float v_min, float v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool SliderFloat2(string label, ref Vector2 v, float v_min, float v_max, string format, ImGuiSliderFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -13061,7 +12025,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -13089,17 +12053,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderFloat3(ReadOnlySpan<char> label, ref Vector3 v, float v_min, float v_max)
-#else
-        public static bool SliderFloat3(string label, ref Vector3 v, float v_min, float v_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -13115,7 +12075,7 @@ namespace ImGuiNET
             else { native_label = null; }
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                format_byteCount = Util.GetUtf8ByteCount("%.3f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -13142,17 +12102,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderFloat3(ReadOnlySpan<char> label, ref Vector3 v, float v_min, float v_max, ReadOnlySpan<char> format)
-#else
-        public static bool SliderFloat3(string label, ref Vector3 v, float v_min, float v_max, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -13170,7 +12126,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -13199,17 +12155,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderFloat3(ReadOnlySpan<char> label, ref Vector3 v, float v_min, float v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool SliderFloat3(string label, ref Vector3 v, float v_min, float v_max, string format, ImGuiSliderFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -13227,7 +12179,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -13255,17 +12207,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderFloat4(ReadOnlySpan<char> label, ref Vector4 v, float v_min, float v_max)
-#else
-        public static bool SliderFloat4(string label, ref Vector4 v, float v_min, float v_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -13281,7 +12229,7 @@ namespace ImGuiNET
             else { native_label = null; }
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                format_byteCount = Util.GetUtf8ByteCount("%.3f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -13308,17 +12256,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderFloat4(ReadOnlySpan<char> label, ref Vector4 v, float v_min, float v_max, ReadOnlySpan<char> format)
-#else
-        public static bool SliderFloat4(string label, ref Vector4 v, float v_min, float v_max, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -13336,7 +12280,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -13365,17 +12309,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderFloat4(ReadOnlySpan<char> label, ref Vector4 v, float v_min, float v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool SliderFloat4(string label, ref Vector4 v, float v_min, float v_max, string format, ImGuiSliderFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -13393,7 +12333,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -13421,17 +12361,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderInt(ReadOnlySpan<char> label, ref int v, int v_min, int v_max)
-#else
-        public static bool SliderInt(string label, ref int v, int v_min, int v_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -13447,7 +12383,7 @@ namespace ImGuiNET
             else { native_label = null; }
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                format_byteCount = Util.GetUtf8ByteCount("%d");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -13474,17 +12410,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderInt(ReadOnlySpan<char> label, ref int v, int v_min, int v_max, ReadOnlySpan<char> format)
-#else
-        public static bool SliderInt(string label, ref int v, int v_min, int v_max, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -13502,7 +12434,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -13531,17 +12463,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderInt(ReadOnlySpan<char> label, ref int v, int v_min, int v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool SliderInt(string label, ref int v, int v_min, int v_max, string format, ImGuiSliderFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -13559,7 +12487,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -13587,17 +12515,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderInt2(ReadOnlySpan<char> label, ref int v, int v_min, int v_max)
-#else
-        public static bool SliderInt2(string label, ref int v, int v_min, int v_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -13613,7 +12537,7 @@ namespace ImGuiNET
             else { native_label = null; }
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                format_byteCount = Util.GetUtf8ByteCount("%d");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -13640,17 +12564,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderInt2(ReadOnlySpan<char> label, ref int v, int v_min, int v_max, ReadOnlySpan<char> format)
-#else
-        public static bool SliderInt2(string label, ref int v, int v_min, int v_max, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -13668,7 +12588,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -13697,17 +12617,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderInt2(ReadOnlySpan<char> label, ref int v, int v_min, int v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool SliderInt2(string label, ref int v, int v_min, int v_max, string format, ImGuiSliderFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -13725,7 +12641,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -13753,17 +12669,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderInt3(ReadOnlySpan<char> label, ref int v, int v_min, int v_max)
-#else
-        public static bool SliderInt3(string label, ref int v, int v_min, int v_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -13779,7 +12691,7 @@ namespace ImGuiNET
             else { native_label = null; }
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                format_byteCount = Util.GetUtf8ByteCount("%d");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -13806,17 +12718,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderInt3(ReadOnlySpan<char> label, ref int v, int v_min, int v_max, ReadOnlySpan<char> format)
-#else
-        public static bool SliderInt3(string label, ref int v, int v_min, int v_max, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -13834,7 +12742,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -13863,17 +12771,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderInt3(ReadOnlySpan<char> label, ref int v, int v_min, int v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool SliderInt3(string label, ref int v, int v_min, int v_max, string format, ImGuiSliderFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -13891,7 +12795,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -13919,17 +12823,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderInt4(ReadOnlySpan<char> label, ref int v, int v_min, int v_max)
-#else
-        public static bool SliderInt4(string label, ref int v, int v_min, int v_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -13945,7 +12845,7 @@ namespace ImGuiNET
             else { native_label = null; }
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                format_byteCount = Util.GetUtf8ByteCount("%d");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -13972,17 +12872,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderInt4(ReadOnlySpan<char> label, ref int v, int v_min, int v_max, ReadOnlySpan<char> format)
-#else
-        public static bool SliderInt4(string label, ref int v, int v_min, int v_max, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -14000,7 +12896,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -14029,17 +12925,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderInt4(ReadOnlySpan<char> label, ref int v, int v_min, int v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool SliderInt4(string label, ref int v, int v_min, int v_max, string format, ImGuiSliderFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -14057,7 +12949,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -14085,17 +12977,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderScalar(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_min, IntPtr p_max)
-#else
-        public static bool SliderScalar(string label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_min, IntPtr p_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -14121,17 +13009,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderScalar(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_min, IntPtr p_max, ReadOnlySpan<char> format)
-#else
-        public static bool SliderScalar(string label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_min, IntPtr p_max, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -14152,7 +13036,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -14178,17 +13062,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderScalar(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_min, IntPtr p_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool SliderScalar(string label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_min, IntPtr p_max, string format, ImGuiSliderFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -14209,7 +13089,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -14234,17 +13114,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderScalarN(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_min, IntPtr p_max)
-#else
-        public static bool SliderScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_min, IntPtr p_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -14270,17 +13146,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderScalarN(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_min, IntPtr p_max, ReadOnlySpan<char> format)
-#else
-        public static bool SliderScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_min, IntPtr p_max, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -14301,7 +13173,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -14327,17 +13199,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderScalarN(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_min, IntPtr p_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool SliderScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_min, IntPtr p_max, string format, ImGuiSliderFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -14358,7 +13226,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -14383,17 +13251,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SmallButton(ReadOnlySpan<char> label)
-#else
-        public static bool SmallButton(string label)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -14448,17 +13312,13 @@ namespace ImGuiNET
             ImGuiStyle* native_dst = dst.NativePtr;
             ImGuiNative.igStyleColorsLight(native_dst);
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool TabItemButton(ReadOnlySpan<char> label)
-#else
-        public static bool TabItemButton(string label)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -14480,17 +13340,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool TabItemButton(ReadOnlySpan<char> label, ImGuiTabItemFlags flags)
-#else
-        public static bool TabItemButton(string label, ImGuiTabItemFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -14553,17 +13409,13 @@ namespace ImGuiNET
             ImGuiTableSortSpecs* ret = ImGuiNative.igTableGetSortSpecs();
             return new ImGuiTableSortSpecsPtr(ret);
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void TableHeader(ReadOnlySpan<char> label)
-#else
-        public static void TableHeader(string label)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -14626,17 +13478,13 @@ namespace ImGuiNET
             byte ret = ImGuiNative.igTableSetColumnIndex(column_n);
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void TableSetupColumn(ReadOnlySpan<char> label)
-#else
-        public static void TableSetupColumn(string label)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -14659,17 +13507,13 @@ namespace ImGuiNET
                 Util.Free(native_label);
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void TableSetupColumn(ReadOnlySpan<char> label, ImGuiTableColumnFlags flags)
-#else
-        public static void TableSetupColumn(string label, ImGuiTableColumnFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -14691,17 +13535,13 @@ namespace ImGuiNET
                 Util.Free(native_label);
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void TableSetupColumn(ReadOnlySpan<char> label, ImGuiTableColumnFlags flags, float init_width_or_weight)
-#else
-        public static void TableSetupColumn(string label, ImGuiTableColumnFlags flags, float init_width_or_weight)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -14722,17 +13562,13 @@ namespace ImGuiNET
                 Util.Free(native_label);
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void TableSetupColumn(ReadOnlySpan<char> label, ImGuiTableColumnFlags flags, float init_width_or_weight, uint user_id)
-#else
-        public static void TableSetupColumn(string label, ImGuiTableColumnFlags flags, float init_width_or_weight, uint user_id)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -14756,17 +13592,13 @@ namespace ImGuiNET
         {
             ImGuiNative.igTableSetupScrollFreeze(cols, rows);
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void Text(ReadOnlySpan<char> fmt)
-#else
-        public static void Text(string fmt)
-#endif
         {
             byte* native_fmt;
             int fmt_byteCount = 0;
             if (fmt != null)
             {
-                fmt_byteCount = Encoding.UTF8.GetByteCount(fmt);
+                fmt_byteCount = Util.GetUtf8ByteCount(fmt);
                 if (fmt_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_fmt = Util.Allocate(fmt_byteCount + 1);
@@ -14786,17 +13618,13 @@ namespace ImGuiNET
                 Util.Free(native_fmt);
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void TextColored(Vector4 col, ReadOnlySpan<char> fmt)
-#else
-        public static void TextColored(Vector4 col, string fmt)
-#endif
         {
             byte* native_fmt;
             int fmt_byteCount = 0;
             if (fmt != null)
             {
-                fmt_byteCount = Encoding.UTF8.GetByteCount(fmt);
+                fmt_byteCount = Util.GetUtf8ByteCount(fmt);
                 if (fmt_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_fmt = Util.Allocate(fmt_byteCount + 1);
@@ -14816,17 +13644,13 @@ namespace ImGuiNET
                 Util.Free(native_fmt);
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void TextDisabled(ReadOnlySpan<char> fmt)
-#else
-        public static void TextDisabled(string fmt)
-#endif
         {
             byte* native_fmt;
             int fmt_byteCount = 0;
             if (fmt != null)
             {
-                fmt_byteCount = Encoding.UTF8.GetByteCount(fmt);
+                fmt_byteCount = Util.GetUtf8ByteCount(fmt);
                 if (fmt_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_fmt = Util.Allocate(fmt_byteCount + 1);
@@ -14846,17 +13670,13 @@ namespace ImGuiNET
                 Util.Free(native_fmt);
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void TextUnformatted(ReadOnlySpan<char> text)
-#else
-        public static void TextUnformatted(string text)
-#endif
         {
             byte* native_text;
             int text_byteCount = 0;
             if (text != null)
             {
-                text_byteCount = Encoding.UTF8.GetByteCount(text);
+                text_byteCount = Util.GetUtf8ByteCount(text);
                 if (text_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_text = Util.Allocate(text_byteCount + 1);
@@ -14877,17 +13697,13 @@ namespace ImGuiNET
                 Util.Free(native_text);
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void TextWrapped(ReadOnlySpan<char> fmt)
-#else
-        public static void TextWrapped(string fmt)
-#endif
         {
             byte* native_fmt;
             int fmt_byteCount = 0;
             if (fmt != null)
             {
-                fmt_byteCount = Encoding.UTF8.GetByteCount(fmt);
+                fmt_byteCount = Util.GetUtf8ByteCount(fmt);
                 if (fmt_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_fmt = Util.Allocate(fmt_byteCount + 1);
@@ -14907,17 +13723,13 @@ namespace ImGuiNET
                 Util.Free(native_fmt);
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool TreeNode(ReadOnlySpan<char> label)
-#else
-        public static bool TreeNode(string label)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -14938,17 +13750,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool TreeNode(ReadOnlySpan<char> str_id, ReadOnlySpan<char> fmt)
-#else
-        public static bool TreeNode(string str_id, string fmt)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -14966,7 +13774,7 @@ namespace ImGuiNET
             int fmt_byteCount = 0;
             if (fmt != null)
             {
-                fmt_byteCount = Encoding.UTF8.GetByteCount(fmt);
+                fmt_byteCount = Util.GetUtf8ByteCount(fmt);
                 if (fmt_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_fmt = Util.Allocate(fmt_byteCount + 1);
@@ -14991,18 +13799,14 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool TreeNode(IntPtr ptr_id, ReadOnlySpan<char> fmt)
-#else
-        public static bool TreeNode(IntPtr ptr_id, string fmt)
-#endif
         {
             void* native_ptr_id = (void*)ptr_id.ToPointer();
             byte* native_fmt;
             int fmt_byteCount = 0;
             if (fmt != null)
             {
-                fmt_byteCount = Encoding.UTF8.GetByteCount(fmt);
+                fmt_byteCount = Util.GetUtf8ByteCount(fmt);
                 if (fmt_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_fmt = Util.Allocate(fmt_byteCount + 1);
@@ -15023,17 +13827,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool TreeNodeEx(ReadOnlySpan<char> label)
-#else
-        public static bool TreeNodeEx(string label)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -15055,17 +13855,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool TreeNodeEx(ReadOnlySpan<char> label, ImGuiTreeNodeFlags flags)
-#else
-        public static bool TreeNodeEx(string label, ImGuiTreeNodeFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -15086,17 +13882,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool TreeNodeEx(ReadOnlySpan<char> str_id, ImGuiTreeNodeFlags flags, ReadOnlySpan<char> fmt)
-#else
-        public static bool TreeNodeEx(string str_id, ImGuiTreeNodeFlags flags, string fmt)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -15114,7 +13906,7 @@ namespace ImGuiNET
             int fmt_byteCount = 0;
             if (fmt != null)
             {
-                fmt_byteCount = Encoding.UTF8.GetByteCount(fmt);
+                fmt_byteCount = Util.GetUtf8ByteCount(fmt);
                 if (fmt_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_fmt = Util.Allocate(fmt_byteCount + 1);
@@ -15139,18 +13931,14 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool TreeNodeEx(IntPtr ptr_id, ImGuiTreeNodeFlags flags, ReadOnlySpan<char> fmt)
-#else
-        public static bool TreeNodeEx(IntPtr ptr_id, ImGuiTreeNodeFlags flags, string fmt)
-#endif
         {
             void* native_ptr_id = (void*)ptr_id.ToPointer();
             byte* native_fmt;
             int fmt_byteCount = 0;
             if (fmt != null)
             {
-                fmt_byteCount = Encoding.UTF8.GetByteCount(fmt);
+                fmt_byteCount = Util.GetUtf8ByteCount(fmt);
                 if (fmt_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_fmt = Util.Allocate(fmt_byteCount + 1);
@@ -15175,17 +13963,13 @@ namespace ImGuiNET
         {
             ImGuiNative.igTreePop();
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void TreePush(ReadOnlySpan<char> str_id)
-#else
-        public static void TreePush(string str_id)
-#endif
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
             if (str_id != null)
             {
-                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                str_id_byteCount = Util.GetUtf8ByteCount(str_id);
                 if (str_id_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str_id = Util.Allocate(str_id_byteCount + 1);
@@ -15223,17 +14007,13 @@ namespace ImGuiNET
         {
             ImGuiNative.igUpdatePlatformWindows();
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void Value(ReadOnlySpan<char> prefix, bool b)
-#else
-        public static void Value(string prefix, bool b)
-#endif
         {
             byte* native_prefix;
             int prefix_byteCount = 0;
             if (prefix != null)
             {
-                prefix_byteCount = Encoding.UTF8.GetByteCount(prefix);
+                prefix_byteCount = Util.GetUtf8ByteCount(prefix);
                 if (prefix_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_prefix = Util.Allocate(prefix_byteCount + 1);
@@ -15254,17 +14034,13 @@ namespace ImGuiNET
                 Util.Free(native_prefix);
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void Value(ReadOnlySpan<char> prefix, int v)
-#else
-        public static void Value(string prefix, int v)
-#endif
         {
             byte* native_prefix;
             int prefix_byteCount = 0;
             if (prefix != null)
             {
-                prefix_byteCount = Encoding.UTF8.GetByteCount(prefix);
+                prefix_byteCount = Util.GetUtf8ByteCount(prefix);
                 if (prefix_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_prefix = Util.Allocate(prefix_byteCount + 1);
@@ -15284,17 +14060,13 @@ namespace ImGuiNET
                 Util.Free(native_prefix);
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void Value(ReadOnlySpan<char> prefix, uint v)
-#else
-        public static void Value(string prefix, uint v)
-#endif
         {
             byte* native_prefix;
             int prefix_byteCount = 0;
             if (prefix != null)
             {
-                prefix_byteCount = Encoding.UTF8.GetByteCount(prefix);
+                prefix_byteCount = Util.GetUtf8ByteCount(prefix);
                 if (prefix_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_prefix = Util.Allocate(prefix_byteCount + 1);
@@ -15314,17 +14086,13 @@ namespace ImGuiNET
                 Util.Free(native_prefix);
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void Value(ReadOnlySpan<char> prefix, float v)
-#else
-        public static void Value(string prefix, float v)
-#endif
         {
             byte* native_prefix;
             int prefix_byteCount = 0;
             if (prefix != null)
             {
-                prefix_byteCount = Encoding.UTF8.GetByteCount(prefix);
+                prefix_byteCount = Util.GetUtf8ByteCount(prefix);
                 if (prefix_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_prefix = Util.Allocate(prefix_byteCount + 1);
@@ -15345,17 +14113,13 @@ namespace ImGuiNET
                 Util.Free(native_prefix);
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void Value(ReadOnlySpan<char> prefix, float v, ReadOnlySpan<char> float_format)
-#else
-        public static void Value(string prefix, float v, string float_format)
-#endif
         {
             byte* native_prefix;
             int prefix_byteCount = 0;
             if (prefix != null)
             {
-                prefix_byteCount = Encoding.UTF8.GetByteCount(prefix);
+                prefix_byteCount = Util.GetUtf8ByteCount(prefix);
                 if (prefix_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_prefix = Util.Allocate(prefix_byteCount + 1);
@@ -15373,7 +14137,7 @@ namespace ImGuiNET
             int float_format_byteCount = 0;
             if (float_format != null)
             {
-                float_format_byteCount = Encoding.UTF8.GetByteCount(float_format);
+                float_format_byteCount = Util.GetUtf8ByteCount(float_format);
                 if (float_format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_float_format = Util.Allocate(float_format_byteCount + 1);
@@ -15397,17 +14161,13 @@ namespace ImGuiNET
                 Util.Free(native_float_format);
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool VSliderFloat(ReadOnlySpan<char> label, Vector2 size, ref float v, float v_min, float v_max)
-#else
-        public static bool VSliderFloat(string label, Vector2 size, ref float v, float v_min, float v_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -15423,7 +14183,7 @@ namespace ImGuiNET
             else { native_label = null; }
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                format_byteCount = Util.GetUtf8ByteCount("%.3f");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -15450,17 +14210,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool VSliderFloat(ReadOnlySpan<char> label, Vector2 size, ref float v, float v_min, float v_max, ReadOnlySpan<char> format)
-#else
-        public static bool VSliderFloat(string label, Vector2 size, ref float v, float v_min, float v_max, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -15478,7 +14234,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -15507,17 +14263,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool VSliderFloat(ReadOnlySpan<char> label, Vector2 size, ref float v, float v_min, float v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool VSliderFloat(string label, Vector2 size, ref float v, float v_min, float v_max, string format, ImGuiSliderFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -15535,7 +14287,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -15563,17 +14315,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool VSliderInt(ReadOnlySpan<char> label, Vector2 size, ref int v, int v_min, int v_max)
-#else
-        public static bool VSliderInt(string label, Vector2 size, ref int v, int v_min, int v_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -15589,7 +14337,7 @@ namespace ImGuiNET
             else { native_label = null; }
             byte* native_format;
             int format_byteCount = 0;
-                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                format_byteCount = Util.GetUtf8ByteCount("%d");
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -15616,17 +14364,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool VSliderInt(ReadOnlySpan<char> label, Vector2 size, ref int v, int v_min, int v_max, ReadOnlySpan<char> format)
-#else
-        public static bool VSliderInt(string label, Vector2 size, ref int v, int v_min, int v_max, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -15644,7 +14388,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -15673,17 +14417,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool VSliderInt(ReadOnlySpan<char> label, Vector2 size, ref int v, int v_min, int v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool VSliderInt(string label, Vector2 size, ref int v, int v_min, int v_max, string format, ImGuiSliderFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -15701,7 +14441,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -15729,17 +14469,13 @@ namespace ImGuiNET
                 return ret != 0;
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool VSliderScalar(ReadOnlySpan<char> label, Vector2 size, ImGuiDataType data_type, IntPtr p_data, IntPtr p_min, IntPtr p_max)
-#else
-        public static bool VSliderScalar(string label, Vector2 size, ImGuiDataType data_type, IntPtr p_data, IntPtr p_min, IntPtr p_max)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -15765,17 +14501,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool VSliderScalar(ReadOnlySpan<char> label, Vector2 size, ImGuiDataType data_type, IntPtr p_data, IntPtr p_min, IntPtr p_max, ReadOnlySpan<char> format)
-#else
-        public static bool VSliderScalar(string label, Vector2 size, ImGuiDataType data_type, IntPtr p_data, IntPtr p_min, IntPtr p_max, string format)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -15796,7 +14528,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);
@@ -15822,17 +14554,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool VSliderScalar(ReadOnlySpan<char> label, Vector2 size, ImGuiDataType data_type, IntPtr p_data, IntPtr p_min, IntPtr p_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool VSliderScalar(string label, Vector2 size, ImGuiDataType data_type, IntPtr p_data, IntPtr p_min, IntPtr p_max, string format, ImGuiSliderFlags flags)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -15853,7 +14581,7 @@ namespace ImGuiNET
             int format_byteCount = 0;
             if (format != null)
             {
-                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                format_byteCount = Util.GetUtf8ByteCount(format);
                 if (format_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_format = Util.Allocate(format_byteCount + 1);

--- a/src/ImGui.NET/Generated/ImGuiIO.gen.cs
+++ b/src/ImGui.NET/Generated/ImGuiIO.gen.cs
@@ -888,17 +888,13 @@ namespace ImGuiNET
         {
             ImGuiNative.ImGuiIO_AddInputCharacter((ImGuiIO*)(NativePtr), c);
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public void AddInputCharactersUTF8(ReadOnlySpan<char> str)
-#else
-        public void AddInputCharactersUTF8(string str)
-#endif
         {
             byte* native_str;
             int str_byteCount = 0;
             if (str != null)
             {
-                str_byteCount = Encoding.UTF8.GetByteCount(str);
+                str_byteCount = Util.GetUtf8ByteCount(str);
                 if (str_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str = Util.Allocate(str_byteCount + 1);

--- a/src/ImGui.NET/Generated/ImGuiInputTextCallbackData.gen.cs
+++ b/src/ImGui.NET/Generated/ImGuiInputTextCallbackData.gen.cs
@@ -59,17 +59,13 @@ namespace ImGuiNET
             byte ret = ImGuiNative.ImGuiInputTextCallbackData_HasSelection((ImGuiInputTextCallbackData*)(NativePtr));
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public void InsertChars(int pos, ReadOnlySpan<char> text)
-#else
-        public void InsertChars(int pos, string text)
-#endif
         {
             byte* native_text;
             int text_byteCount = 0;
             if (text != null)
             {
-                text_byteCount = Encoding.UTF8.GetByteCount(text);
+                text_byteCount = Util.GetUtf8ByteCount(text);
                 if (text_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_text = Util.Allocate(text_byteCount + 1);

--- a/src/ImGui.NET/Generated/ImGuiPayload.gen.cs
+++ b/src/ImGui.NET/Generated/ImGuiPayload.gen.cs
@@ -40,17 +40,13 @@ namespace ImGuiNET
         {
             ImGuiNative.ImGuiPayload_destroy((ImGuiPayload*)(NativePtr));
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public bool IsDataType(ReadOnlySpan<char> type)
-#else
-        public bool IsDataType(string type)
-#endif
         {
             byte* native_type;
             int type_byteCount = 0;
             if (type != null)
             {
-                type_byteCount = Encoding.UTF8.GetByteCount(type);
+                type_byteCount = Util.GetUtf8ByteCount(type);
                 if (type_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_type = Util.Allocate(type_byteCount + 1);

--- a/src/ImGui.NET/Generated/ImGuiTextBuffer.gen.cs
+++ b/src/ImGui.NET/Generated/ImGuiTextBuffer.gen.cs
@@ -18,17 +18,13 @@ namespace ImGuiNET
         public static implicit operator ImGuiTextBuffer* (ImGuiTextBufferPtr wrappedPtr) => wrappedPtr.NativePtr;
         public static implicit operator ImGuiTextBufferPtr(IntPtr nativePtr) => new ImGuiTextBufferPtr(nativePtr);
         public ImVector<byte> Buf => new ImVector<byte>(NativePtr->Buf);
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public void append(ReadOnlySpan<char> str)
-#else
-        public void append(string str)
-#endif
         {
             byte* native_str;
             int str_byteCount = 0;
             if (str != null)
             {
-                str_byteCount = Encoding.UTF8.GetByteCount(str);
+                str_byteCount = Util.GetUtf8ByteCount(str);
                 if (str_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_str = Util.Allocate(str_byteCount + 1);
@@ -49,17 +45,13 @@ namespace ImGuiNET
                 Util.Free(native_str);
             }
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public void appendf(ReadOnlySpan<char> fmt)
-#else
-        public void appendf(string fmt)
-#endif
         {
             byte* native_fmt;
             int fmt_byteCount = 0;
             if (fmt != null)
             {
-                fmt_byteCount = Encoding.UTF8.GetByteCount(fmt);
+                fmt_byteCount = Util.GetUtf8ByteCount(fmt);
                 if (fmt_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_fmt = Util.Allocate(fmt_byteCount + 1);

--- a/src/ImGui.NET/Generated/ImGuiTextFilter.gen.cs
+++ b/src/ImGui.NET/Generated/ImGuiTextFilter.gen.cs
@@ -38,7 +38,7 @@ namespace ImGuiNET
         {
             byte* native_label;
             int label_byteCount = 0;
-                label_byteCount = Encoding.UTF8.GetByteCount("Filter(inc,-exc)");
+                label_byteCount = Util.GetUtf8ByteCount("Filter(inc,-exc)");
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -58,17 +58,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public bool Draw(ReadOnlySpan<char> label)
-#else
-        public bool Draw(string label)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -90,17 +86,13 @@ namespace ImGuiNET
             }
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public bool Draw(ReadOnlySpan<char> label, float width)
-#else
-        public bool Draw(string label, float width)
-#endif
         {
             byte* native_label;
             int label_byteCount = 0;
             if (label != null)
             {
-                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                label_byteCount = Util.GetUtf8ByteCount(label);
                 if (label_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_label = Util.Allocate(label_byteCount + 1);
@@ -126,17 +118,13 @@ namespace ImGuiNET
             byte ret = ImGuiNative.ImGuiTextFilter_IsActive((ImGuiTextFilter*)(NativePtr));
             return ret != 0;
         }
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public bool PassFilter(ReadOnlySpan<char> text)
-#else
-        public bool PassFilter(string text)
-#endif
         {
             byte* native_text;
             int text_byteCount = 0;
             if (text != null)
             {
-                text_byteCount = Encoding.UTF8.GetByteCount(text);
+                text_byteCount = Util.GetUtf8ByteCount(text);
                 if (text_byteCount > Util.StackAllocationSizeLimit)
                 {
                     native_text = Util.Allocate(text_byteCount + 1);

--- a/src/ImGui.NET/ImDrawList.Manual.cs
+++ b/src/ImGui.NET/ImDrawList.Manual.cs
@@ -1,13 +1,14 @@
-﻿using System.Numerics;
+﻿using System;
+using System.Numerics;
 using System.Text;
 
 namespace ImGuiNET
 {
     public unsafe partial struct ImDrawListPtr
     {
-        public void AddText(Vector2 pos, uint col, string text_begin)
+        public void AddText(Vector2 pos, uint col, ReadOnlySpan<char> text_begin)
         {
-            int text_begin_byteCount = Encoding.UTF8.GetByteCount(text_begin);
+            int text_begin_byteCount = Util.GetUtf8ByteCount(text_begin);
             byte* native_text_begin = stackalloc byte[text_begin_byteCount + 1];
             fixed (char* text_begin_ptr = text_begin)
             {
@@ -18,10 +19,10 @@ namespace ImGuiNET
             ImGuiNative.ImDrawList_AddText_Vec2(NativePtr, pos, col, native_text_begin, native_text_end);
         }
 
-        public void AddText(ImFontPtr font, float font_size, Vector2 pos, uint col, string text_begin)
+        public void AddText(ImFontPtr font, float font_size, Vector2 pos, uint col, ReadOnlySpan<char> text_begin)
         {
             ImFont* native_font = font.NativePtr;
-            int text_begin_byteCount = Encoding.UTF8.GetByteCount(text_begin);
+            int text_begin_byteCount = Util.GetUtf8ByteCount(text_begin);
             byte* native_text_begin = stackalloc byte[text_begin_byteCount + 1];
             fixed (char* text_begin_ptr = text_begin)
             {

--- a/src/ImGui.NET/ImGui.Manual.cs
+++ b/src/ImGui.NET/ImGui.Manual.cs
@@ -9,7 +9,7 @@ namespace ImGuiNET
     public static unsafe partial class ImGui
     {
         public static bool InputText(
-            string label,
+            ReadOnlySpan<char> label,
             byte[] buf,
             uint buf_size)
         {
@@ -17,7 +17,7 @@ namespace ImGuiNET
         }
 
         public static bool InputText(
-            string label,
+            ReadOnlySpan<char> label,
             byte[] buf,
             uint buf_size,
             ImGuiInputTextFlags flags)
@@ -26,7 +26,7 @@ namespace ImGuiNET
         }
 
         public static bool InputText(
-            string label,
+            ReadOnlySpan<char> label,
             byte[] buf,
             uint buf_size,
             ImGuiInputTextFlags flags,
@@ -36,14 +36,14 @@ namespace ImGuiNET
         }
 
         public static bool InputText(
-            string label,
+            ReadOnlySpan<char> label,
             byte[] buf,
             uint buf_size,
             ImGuiInputTextFlags flags,
             ImGuiInputTextCallback callback,
             IntPtr user_data)
         {
-            int utf8LabelByteCount = Encoding.UTF8.GetByteCount(label);
+            int utf8LabelByteCount = Util.GetUtf8ByteCount(label);
             byte* utf8LabelBytes;
             if (utf8LabelByteCount > Util.StackAllocationSizeLimit)
             {
@@ -71,32 +71,32 @@ namespace ImGuiNET
         }
 
         public static bool InputText(
-            string label,
+            ReadOnlySpan<char> label,
             ref string input,
             uint maxLength) => InputText(label, ref input, maxLength, 0, null, IntPtr.Zero);
 
         public static bool InputText(
-            string label,
+            ReadOnlySpan<char> label,
             ref string input,
             uint maxLength,
             ImGuiInputTextFlags flags) => InputText(label, ref input, maxLength, flags, null, IntPtr.Zero);
 
         public static bool InputText(
-            string label,
+            ReadOnlySpan<char> label,
             ref string input,
             uint maxLength,
             ImGuiInputTextFlags flags,
             ImGuiInputTextCallback callback) => InputText(label, ref input, maxLength, flags, callback, IntPtr.Zero);
 
         public static bool InputText(
-            string label,
+            ReadOnlySpan<char> label,
             ref string input,
             uint maxLength,
             ImGuiInputTextFlags flags,
             ImGuiInputTextCallback callback,
             IntPtr user_data)
         {
-            int utf8LabelByteCount = Encoding.UTF8.GetByteCount(label);
+            int utf8LabelByteCount = Util.GetUtf8ByteCount(label);
             byte* utf8LabelBytes;
             if (utf8LabelByteCount > Util.StackAllocationSizeLimit)
             {
@@ -109,7 +109,7 @@ namespace ImGuiNET
             }
             Util.GetUtf8(label, utf8LabelBytes, utf8LabelByteCount);
 
-            int utf8InputByteCount = Encoding.UTF8.GetByteCount(input);
+            int utf8InputByteCount = Util.GetUtf8ByteCount(input);
             int inputBufSize = Math.Max((int)maxLength + 1, utf8InputByteCount + 1);
 
             byte* utf8InputBytes;
@@ -157,20 +157,20 @@ namespace ImGuiNET
         }
 
         public static bool InputTextMultiline(
-            string label,
+            ReadOnlySpan<char> label,
             ref string input,
             uint maxLength,
             Vector2 size) => InputTextMultiline(label, ref input, maxLength, size, 0, null, IntPtr.Zero);
 
         public static bool InputTextMultiline(
-            string label,
+            ReadOnlySpan<char> label,
             ref string input,
             uint maxLength,
             Vector2 size,
             ImGuiInputTextFlags flags) => InputTextMultiline(label, ref input, maxLength, size, flags, null, IntPtr.Zero);
 
         public static bool InputTextMultiline(
-            string label,
+            ReadOnlySpan<char> label,
             ref string input,
             uint maxLength,
             Vector2 size,
@@ -178,7 +178,7 @@ namespace ImGuiNET
             ImGuiInputTextCallback callback) => InputTextMultiline(label, ref input, maxLength, size, flags, callback, IntPtr.Zero);
 
         public static bool InputTextMultiline(
-            string label,
+            ReadOnlySpan<char> label,
             ref string input,
             uint maxLength,
             Vector2 size,
@@ -186,7 +186,7 @@ namespace ImGuiNET
             ImGuiInputTextCallback callback,
             IntPtr user_data)
         {
-            int utf8LabelByteCount = Encoding.UTF8.GetByteCount(label);
+            int utf8LabelByteCount = Util.GetUtf8ByteCount(label);
             byte* utf8LabelBytes;
             if (utf8LabelByteCount > Util.StackAllocationSizeLimit)
             {
@@ -199,7 +199,7 @@ namespace ImGuiNET
             }
             Util.GetUtf8(label, utf8LabelBytes, utf8LabelByteCount);
 
-            int utf8InputByteCount = Encoding.UTF8.GetByteCount(input);
+            int utf8InputByteCount = Util.GetUtf8ByteCount(input);
             int inputBufSize = Math.Max((int)maxLength + 1, utf8InputByteCount + 1);
 
             byte* utf8InputBytes;
@@ -248,36 +248,36 @@ namespace ImGuiNET
         }
 
         public static bool InputTextWithHint(
-            string label,
-            string hint,
+            ReadOnlySpan<char> label,
+            ReadOnlySpan<char> hint,
             ref string input,
             uint maxLength) => InputTextWithHint(label, hint, ref input, maxLength, 0, null, IntPtr.Zero);
 
         public static bool InputTextWithHint(
-            string label,
-            string hint,
+            ReadOnlySpan<char> label,
+            ReadOnlySpan<char> hint,
             ref string input,
             uint maxLength,
             ImGuiInputTextFlags flags) => InputTextWithHint(label, hint, ref input, maxLength, flags, null, IntPtr.Zero);
 
         public static bool InputTextWithHint(
-            string label,
-            string hint,
+            ReadOnlySpan<char> label,
+            ReadOnlySpan<char> hint,
             ref string input,
             uint maxLength,
             ImGuiInputTextFlags flags,
             ImGuiInputTextCallback callback) => InputTextWithHint(label, hint, ref input, maxLength, flags, callback, IntPtr.Zero);
 
         public static bool InputTextWithHint(
-            string label,
-            string hint,
+            ReadOnlySpan<char> label,
+            ReadOnlySpan<char> hint,
             ref string input,
             uint maxLength,
             ImGuiInputTextFlags flags,
             ImGuiInputTextCallback callback,
             IntPtr user_data)
         {
-            int utf8LabelByteCount = Encoding.UTF8.GetByteCount(label);
+            int utf8LabelByteCount = Util.GetUtf8ByteCount(label);
             byte* utf8LabelBytes;
             if (utf8LabelByteCount > Util.StackAllocationSizeLimit)
             {
@@ -290,7 +290,7 @@ namespace ImGuiNET
             }
             Util.GetUtf8(label, utf8LabelBytes, utf8LabelByteCount);
 
-            int utf8HintByteCount = Encoding.UTF8.GetByteCount(hint);
+            int utf8HintByteCount = Util.GetUtf8ByteCount(hint);
             byte* utf8HintBytes;
             if (utf8HintByteCount > Util.StackAllocationSizeLimit)
             {
@@ -355,41 +355,41 @@ namespace ImGuiNET
             return result != 0;
         }
 
-        public static Vector2 CalcTextSize(string text)
+        public static Vector2 CalcTextSize(ReadOnlySpan<char> text)
             => CalcTextSizeImpl(text);
 
-        public static Vector2 CalcTextSize(string text, int start)
+        public static Vector2 CalcTextSize(ReadOnlySpan<char> text, int start)
             => CalcTextSizeImpl(text, start);
 
-        public static Vector2 CalcTextSize(string text, float wrapWidth)
+        public static Vector2 CalcTextSize(ReadOnlySpan<char> text, float wrapWidth)
             => CalcTextSizeImpl(text, wrapWidth: wrapWidth);
 
-        public static Vector2 CalcTextSize(string text, bool hideTextAfterDoubleHash)
+        public static Vector2 CalcTextSize(ReadOnlySpan<char> text, bool hideTextAfterDoubleHash)
             => CalcTextSizeImpl(text, hideTextAfterDoubleHash: hideTextAfterDoubleHash);
 
-        public static Vector2 CalcTextSize(string text, int start, int length)
+        public static Vector2 CalcTextSize(ReadOnlySpan<char> text, int start, int length)
             => CalcTextSizeImpl(text, start, length);
 
-        public static Vector2 CalcTextSize(string text, int start, bool hideTextAfterDoubleHash)
+        public static Vector2 CalcTextSize(ReadOnlySpan<char> text, int start, bool hideTextAfterDoubleHash)
             => CalcTextSizeImpl(text, start, hideTextAfterDoubleHash: hideTextAfterDoubleHash);
 
-        public static Vector2 CalcTextSize(string text, int start, float wrapWidth)
+        public static Vector2 CalcTextSize(ReadOnlySpan<char> text, int start, float wrapWidth)
             => CalcTextSizeImpl(text, start, wrapWidth: wrapWidth);
 
-        public static Vector2 CalcTextSize(string text, bool hideTextAfterDoubleHash, float wrapWidth)
+        public static Vector2 CalcTextSize(ReadOnlySpan<char> text, bool hideTextAfterDoubleHash, float wrapWidth)
             => CalcTextSizeImpl(text, hideTextAfterDoubleHash: hideTextAfterDoubleHash, wrapWidth: wrapWidth);
 
-        public static Vector2 CalcTextSize(string text, int start, int length, bool hideTextAfterDoubleHash)
+        public static Vector2 CalcTextSize(ReadOnlySpan<char> text, int start, int length, bool hideTextAfterDoubleHash)
             => CalcTextSizeImpl(text, start, length, hideTextAfterDoubleHash);
 
-        public static Vector2 CalcTextSize(string text, int start, int length, float wrapWidth)
+        public static Vector2 CalcTextSize(ReadOnlySpan<char> text, int start, int length, float wrapWidth)
             => CalcTextSizeImpl(text, start, length, wrapWidth: wrapWidth);
 
-        public static Vector2 CalcTextSize(string text, int start, int length, bool hideTextAfterDoubleHash, float wrapWidth)
+        public static Vector2 CalcTextSize(ReadOnlySpan<char> text, int start, int length, bool hideTextAfterDoubleHash, float wrapWidth)
             => CalcTextSizeImpl(text, start, length, hideTextAfterDoubleHash, wrapWidth);
 
         private static Vector2 CalcTextSizeImpl(
-            string text,
+            ReadOnlySpan<char> text,
             int start = 0,
             int? length = null,
             bool hideTextAfterDoubleHash = false,
@@ -429,7 +429,7 @@ namespace ImGuiNET
         }
 
         public static bool InputText(
-            string label,
+            ReadOnlySpan<char> label,
             IntPtr buf,
             uint buf_size)
         {
@@ -437,7 +437,7 @@ namespace ImGuiNET
         }
 
         public static bool InputText(
-            string label,
+            ReadOnlySpan<char> label,
             IntPtr buf,
             uint buf_size,
             ImGuiInputTextFlags flags)
@@ -446,7 +446,7 @@ namespace ImGuiNET
         }
 
         public static bool InputText(
-            string label,
+            ReadOnlySpan<char> label,
             IntPtr buf,
             uint buf_size,
             ImGuiInputTextFlags flags,
@@ -456,14 +456,14 @@ namespace ImGuiNET
         }
 
         public static bool InputText(
-            string label,
+            ReadOnlySpan<char> label,
             IntPtr buf,
             uint buf_size,
             ImGuiInputTextFlags flags,
             ImGuiInputTextCallback callback,
             IntPtr user_data)
         {
-            int utf8LabelByteCount = Encoding.UTF8.GetByteCount(label);
+            int utf8LabelByteCount = Util.GetUtf8ByteCount(label);
             byte* utf8LabelBytes;
             if (utf8LabelByteCount > Util.StackAllocationSizeLimit)
             {
@@ -486,9 +486,9 @@ namespace ImGuiNET
             return ret;
         }
 
-        public static bool Begin(string name, ImGuiWindowFlags flags)
+        public static bool Begin(ReadOnlySpan<char> name, ImGuiWindowFlags flags)
         {
-            int utf8NameByteCount = Encoding.UTF8.GetByteCount(name);
+            int utf8NameByteCount = Util.GetUtf8ByteCount(name);
             byte* utf8NameBytes;
             if (utf8NameByteCount > Util.StackAllocationSizeLimit)
             {
@@ -512,9 +512,9 @@ namespace ImGuiNET
             return ret != 0;
         }
 
-        public static bool MenuItem(string label, bool enabled)
+        public static bool MenuItem(ReadOnlySpan<char> label, bool enabled)
         {
-            return MenuItem(label, string.Empty, false, enabled);
+            return MenuItem(label, ReadOnlySpan<char>.Empty, false, enabled);
         }
     }
 }

--- a/src/ImGui.NET/ImGui.NET.csproj
+++ b/src/ImGui.NET/ImGui.NET.csproj
@@ -16,9 +16,10 @@
     <RootNamespace>ImGuiNET</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Numerics.Vectors" Version="4.4.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" />
-    <PackageReference Include="System.Buffers" Version="4.4.0" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">

--- a/src/ImGuizmo.NET/ImGuizmo.NET.csproj
+++ b/src/ImGuizmo.NET/ImGuizmo.NET.csproj
@@ -16,9 +16,10 @@
     <RootNamespace>ImPlotNET</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Numerics.Vectors" Version="4.4.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" />
-    <PackageReference Include="System.Buffers" Version="4.4.0" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ImGui.NET\ImGui.NET.csproj" />

--- a/src/ImNodes.NET/ImNodes.NET.csproj
+++ b/src/ImNodes.NET/ImNodes.NET.csproj
@@ -16,9 +16,10 @@
     <RootNamespace>imnodesNET</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Numerics.Vectors" Version="4.4.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" />
-    <PackageReference Include="System.Buffers" Version="4.4.0" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ImGui.NET\ImGui.NET.csproj" />

--- a/src/ImPlot.NET/ImPlot.NET.csproj
+++ b/src/ImPlot.NET/ImPlot.NET.csproj
@@ -16,9 +16,10 @@
     <RootNamespace>ImPlotNET</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Numerics.Vectors" Version="4.4.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" />
-    <PackageReference Include="System.Buffers" Version="4.4.0" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ImGui.NET\ImGui.NET.csproj" />


### PR DESCRIPTION
This PR is basically a rework of my original PR: https://github.com/ImGuiNET/ImGui.NET/pull/405

Changes compared to my original PR:
- Instead of generating code with preprocessor directives, the System.Memory package has been installed which allows for use of the `ReadOnlySpan` struct without dropping support for .NET Standard.

New changes:
- ImGui.Manual and ImDrawList.Manual now support `ReadOnlySpan<char>` as well.
- The overload for `Encoding.UTF8.GetByteCount` that accepts `ReadOnlySpan<char>` is unfortunately not present in System.Memory, so I had to add an internal method to the `Util` class to make it work. This has been applied to both generated and manual ImGui code.
- I have updated the following dependencies, otherwise we could not use the latest version of System.Memory:
  - System.Buffers: 4.4.0 -> 4.5.1
  - System.Numerics.Vectors: 4.4.0 -> 4.5.0
  - System.Runtime.CompilerServices.Unsafe: 4.4.0 -> 6.0.0

Questions:
- What should be done with the `ref string` parameters in ImGui.Manual.cs?
- The previous PR introduced an issue that would cause `string.Empty` to crash the `ImGui.Text` method for instance. This has been fixed by simply returning 0 when the span was empty. Perhaps we need to do this in more places.
- I feel like it might be a good idea to set up a unit test project for the `Util` methods. Thoughts?

Both samples are running fine (but I have not done any extensive testing).