### PR TITLE
Fix backwards incompatibility with .NET standard 2.0 by re-adding overloads with string parameters

### DIFF
--- a/src/ImGui.NET.SampleProgram/ImGui.NET.SampleProgram.csproj
+++ b/src/ImGui.NET.SampleProgram/ImGui.NET.SampleProgram.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Veldrid" Version="4.8.0" />
     <PackageReference Include="Veldrid.StartupUtilities" Version="4.8.0" />
     <ProjectReference Include="..\ImPlot.NET\ImPlot.NET.csproj" />
+    <ProjectReference Include="..\TestDotNetStandardLib\TestDotNetStandardLib.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ImGui.NET.SampleProgram/Program.cs
+++ b/src/ImGui.NET.SampleProgram/Program.cs
@@ -94,7 +94,6 @@ namespace ImGuiNET
                 ImGui.Text("");
                 ImGui.Text(string.Empty);
                 ImGui.Text("Hello, world!");                                        // Display some text (you can use a format string too)
-                
                 ImGui.SliderFloat("float", ref _f, 0, 1, _f.ToString("0.000"));  // Edit 1 float using a slider from 0.0f to 1.0f    
                 //ImGui.ColorEdit3("clear color", ref _clearColor);                   // Edit 3 floats representing a color
 

--- a/src/ImGui.NET.SampleProgram/Program.cs
+++ b/src/ImGui.NET.SampleProgram/Program.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Numerics;
 using ImPlotNET;
+using TestDotNetStandardLib;
 using Veldrid;
 using Veldrid.Sdl2;
 using Veldrid.StartupUtilities;
@@ -89,9 +90,19 @@ namespace ImGuiNET
             // 1. Show a simple window.
             // Tip: if we don't call ImGui.Begin(string) / ImGui.End() the widgets automatically appears in a window called "Debug".
             {
+                TestStringParameterOnDotNetStandard.Text();
                 ImGui.Text("");
                 ImGui.Text(string.Empty);
-                ImGui.Text("Hello, world!");                                        // Display some text (you can use a format string too)
+                long allocBytesStringStart = GC.GetAllocatedBytesForCurrentThread();
+                ImGui.Text("Hello, world!"); // Display some text (you can use a format string too)
+                long allocBytesStringEnd = GC.GetAllocatedBytesForCurrentThread() - allocBytesStringStart;
+                Console.WriteLine("GC (string): " + allocBytesStringEnd);
+                
+                long allocBytesSpanStart = GC.GetAllocatedBytesForCurrentThread();
+                ImGui.Text("Hello, world!".AsSpan()); // Display some text (you can use a format string too)
+                long allocBytesSpanEnd = GC.GetAllocatedBytesForCurrentThread() - allocBytesSpanStart;
+                Console.WriteLine("GC (span): " + allocBytesSpanEnd);
+                
                 ImGui.SliderFloat("float", ref _f, 0, 1, _f.ToString("0.000"));  // Edit 1 float using a slider from 0.0f to 1.0f    
                 //ImGui.ColorEdit3("clear color", ref _clearColor);                   // Edit 3 floats representing a color
 
@@ -167,9 +178,9 @@ namespace ImGuiNET
                     if ((s_tab_bar_flags & (uint)ImGuiTabBarFlags.FittingPolicyMask) == 0)
                         s_tab_bar_flags |= (uint)ImGuiTabBarFlags.FittingPolicyDefault;
                     if (ImGui.CheckboxFlags("ImGuiTabBarFlags_FittingPolicyResizeDown", ref s_tab_bar_flags, (uint)ImGuiTabBarFlags.FittingPolicyResizeDown))
-                s_tab_bar_flags &= ~((uint)ImGuiTabBarFlags.FittingPolicyMask ^ (uint)ImGuiTabBarFlags.FittingPolicyResizeDown);
+                        s_tab_bar_flags &= ~((uint)ImGuiTabBarFlags.FittingPolicyMask ^ (uint)ImGuiTabBarFlags.FittingPolicyResizeDown);
                     if (ImGui.CheckboxFlags("ImGuiTabBarFlags_FittingPolicyScroll", ref s_tab_bar_flags, (uint)ImGuiTabBarFlags.FittingPolicyScroll))
-                s_tab_bar_flags &= ~((uint)ImGuiTabBarFlags.FittingPolicyMask ^ (uint)ImGuiTabBarFlags.FittingPolicyScroll);
+                        s_tab_bar_flags &= ~((uint)ImGuiTabBarFlags.FittingPolicyMask ^ (uint)ImGuiTabBarFlags.FittingPolicyScroll);
 
                     // Tab Bar
                     string[] names = { "Artichoke", "Beetroot", "Celery", "Daikon" };

--- a/src/ImGui.NET.SampleProgram/Program.cs
+++ b/src/ImGui.NET.SampleProgram/Program.cs
@@ -220,7 +220,7 @@ namespace ImGuiNET
             Console.WriteLine("GC (string): " + allocBytesStringEnd);
                 
             long allocBytesSpanStart = GC.GetAllocatedBytesForCurrentThread();
-            ImGui.Text($"Hello, world {Random.Shared.Next(100)}!"); // Note that this call will STILL allocate memory due to string interpolation, but you can prevent that from happening by using an InterpolatedStringHandler.
+            ImGui.Text($"Hello, world {Random.Shared.Next(100)}!".AsSpan()); // Note that this call will STILL allocate memory due to string interpolation, but you can prevent that from happening by using an InterpolatedStringHandler.
             long allocBytesSpanEnd = GC.GetAllocatedBytesForCurrentThread() - allocBytesSpanStart;
             Console.WriteLine("GC (span): " + allocBytesSpanEnd);
         }

--- a/src/ImGui.NET.SampleProgram/Program.cs
+++ b/src/ImGui.NET.SampleProgram/Program.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Numerics;
 using ImPlotNET;
+using System.Runtime.CompilerServices;
 using TestDotNetStandardLib;
 using Veldrid;
 using Veldrid.Sdl2;
@@ -90,18 +91,9 @@ namespace ImGuiNET
             // 1. Show a simple window.
             // Tip: if we don't call ImGui.Begin(string) / ImGui.End() the widgets automatically appears in a window called "Debug".
             {
-                TestStringParameterOnDotNetStandard.Text();
                 ImGui.Text("");
                 ImGui.Text(string.Empty);
-                long allocBytesStringStart = GC.GetAllocatedBytesForCurrentThread();
-                ImGui.Text("Hello, world!"); // Display some text (you can use a format string too)
-                long allocBytesStringEnd = GC.GetAllocatedBytesForCurrentThread() - allocBytesStringStart;
-                Console.WriteLine("GC (string): " + allocBytesStringEnd);
-                
-                long allocBytesSpanStart = GC.GetAllocatedBytesForCurrentThread();
-                ImGui.Text("Hello, world!".AsSpan()); // Display some text (you can use a format string too)
-                long allocBytesSpanEnd = GC.GetAllocatedBytesForCurrentThread() - allocBytesSpanStart;
-                Console.WriteLine("GC (span): " + allocBytesSpanEnd);
+                ImGui.Text("Hello, world!");                                        // Display some text (you can use a format string too)
                 
                 ImGui.SliderFloat("float", ref _f, 0, 1, _f.ToString("0.000"));  // Edit 1 float using a slider from 0.0f to 1.0f    
                 //ImGui.ColorEdit3("clear color", ref _clearColor);                   // Edit 3 floats representing a color
@@ -218,6 +210,20 @@ namespace ImGuiNET
                 ImGui.Text("Memory editor currently supported.");
                 // _memoryEditor.Draw("Memory Editor", _memoryEditorData, _memoryEditorData.Length);
             }
+            
+            // ReadOnlySpan<char> and .NET Standard 2.0 tests
+            TestStringParameterOnDotNetStandard.Text(); // String overloads should always be available.
+            
+            // On .NET Standard 2.1 or greater, you can use ReadOnlySpan<char> instead of string to prevent allocations.
+            long allocBytesStringStart = GC.GetAllocatedBytesForCurrentThread();
+            ImGui.Text($"Hello, world {Random.Shared.Next(100)}!");
+            long allocBytesStringEnd = GC.GetAllocatedBytesForCurrentThread() - allocBytesStringStart;
+            Console.WriteLine("GC (string): " + allocBytesStringEnd);
+                
+            long allocBytesSpanStart = GC.GetAllocatedBytesForCurrentThread();
+            ImGui.Text($"Hello, world {Random.Shared.Next(100)}!"); // Note that this call will STILL allocate memory due to string interpolation, but you can prevent that from happening by using an InterpolatedStringHandler.
+            long allocBytesSpanEnd = GC.GetAllocatedBytesForCurrentThread() - allocBytesSpanStart;
+            Console.WriteLine("GC (span): " + allocBytesSpanEnd);
         }
     }
 }

--- a/src/ImGui.NET.sln
+++ b/src/ImGui.NET.sln
@@ -16,6 +16,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImNodes.NET", "ImNodes.NET\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImGuizmo.NET", "ImGuizmo.NET\ImGuizmo.NET.csproj", "{760568AB-DCC9-443E-ADFA-2B06B2E2B421}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestDotNetStandardLib", "TestDotNetStandardLib\TestDotNetStandardLib.csproj", "{867D8763-15A2-40E4-AAFD-43B77AC52154}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -110,6 +112,18 @@ Global
 		{760568AB-DCC9-443E-ADFA-2B06B2E2B421}.Release|x64.Build.0 = Release|Any CPU
 		{760568AB-DCC9-443E-ADFA-2B06B2E2B421}.Release|x86.ActiveCfg = Release|Any CPU
 		{760568AB-DCC9-443E-ADFA-2B06B2E2B421}.Release|x86.Build.0 = Release|Any CPU
+		{867D8763-15A2-40E4-AAFD-43B77AC52154}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{867D8763-15A2-40E4-AAFD-43B77AC52154}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{867D8763-15A2-40E4-AAFD-43B77AC52154}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{867D8763-15A2-40E4-AAFD-43B77AC52154}.Debug|x64.Build.0 = Debug|Any CPU
+		{867D8763-15A2-40E4-AAFD-43B77AC52154}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{867D8763-15A2-40E4-AAFD-43B77AC52154}.Debug|x86.Build.0 = Debug|Any CPU
+		{867D8763-15A2-40E4-AAFD-43B77AC52154}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{867D8763-15A2-40E4-AAFD-43B77AC52154}.Release|Any CPU.Build.0 = Release|Any CPU
+		{867D8763-15A2-40E4-AAFD-43B77AC52154}.Release|x64.ActiveCfg = Release|Any CPU
+		{867D8763-15A2-40E4-AAFD-43B77AC52154}.Release|x64.Build.0 = Release|Any CPU
+		{867D8763-15A2-40E4-AAFD-43B77AC52154}.Release|x86.ActiveCfg = Release|Any CPU
+		{867D8763-15A2-40E4-AAFD-43B77AC52154}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ImGui.NET/Generated/ImFontAtlas.gen.cs
+++ b/src/ImGui.NET/Generated/ImFontAtlas.gen.cs
@@ -161,9 +161,36 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public ImFontPtr AddFontFromFileTTF(ReadOnlySpan<char> filename, float size_pixels)
-#else
-        public ImFontPtr AddFontFromFileTTF(string filename, float size_pixels)
+        {
+            byte* native_filename;
+            int filename_byteCount = 0;
+            if (filename != null)
+            {
+                filename_byteCount = Encoding.UTF8.GetByteCount(filename);
+                if (filename_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_filename = Util.Allocate(filename_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_filename_stackBytes = stackalloc byte[filename_byteCount + 1];
+                    native_filename = native_filename_stackBytes;
+                }
+                int native_filename_offset = Util.GetUtf8(filename, native_filename, filename_byteCount);
+                native_filename[native_filename_offset] = 0;
+            }
+            else { native_filename = null; }
+            ImFontConfig* font_cfg = null;
+            ushort* glyph_ranges = null;
+            ImFont* ret = ImGuiNative.ImFontAtlas_AddFontFromFileTTF((ImFontAtlas*)(NativePtr), native_filename, size_pixels, font_cfg, glyph_ranges);
+            if (filename_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_filename);
+            }
+            return new ImFontPtr(ret);
+        }
 #endif
+        public ImFontPtr AddFontFromFileTTF(string filename, float size_pixels)
         {
             byte* native_filename;
             int filename_byteCount = 0;
@@ -194,9 +221,36 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public ImFontPtr AddFontFromFileTTF(ReadOnlySpan<char> filename, float size_pixels, ImFontConfigPtr font_cfg)
-#else
-        public ImFontPtr AddFontFromFileTTF(string filename, float size_pixels, ImFontConfigPtr font_cfg)
+        {
+            byte* native_filename;
+            int filename_byteCount = 0;
+            if (filename != null)
+            {
+                filename_byteCount = Encoding.UTF8.GetByteCount(filename);
+                if (filename_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_filename = Util.Allocate(filename_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_filename_stackBytes = stackalloc byte[filename_byteCount + 1];
+                    native_filename = native_filename_stackBytes;
+                }
+                int native_filename_offset = Util.GetUtf8(filename, native_filename, filename_byteCount);
+                native_filename[native_filename_offset] = 0;
+            }
+            else { native_filename = null; }
+            ImFontConfig* native_font_cfg = font_cfg.NativePtr;
+            ushort* glyph_ranges = null;
+            ImFont* ret = ImGuiNative.ImFontAtlas_AddFontFromFileTTF((ImFontAtlas*)(NativePtr), native_filename, size_pixels, native_font_cfg, glyph_ranges);
+            if (filename_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_filename);
+            }
+            return new ImFontPtr(ret);
+        }
 #endif
+        public ImFontPtr AddFontFromFileTTF(string filename, float size_pixels, ImFontConfigPtr font_cfg)
         {
             byte* native_filename;
             int filename_byteCount = 0;
@@ -227,9 +281,36 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public ImFontPtr AddFontFromFileTTF(ReadOnlySpan<char> filename, float size_pixels, ImFontConfigPtr font_cfg, IntPtr glyph_ranges)
-#else
-        public ImFontPtr AddFontFromFileTTF(string filename, float size_pixels, ImFontConfigPtr font_cfg, IntPtr glyph_ranges)
+        {
+            byte* native_filename;
+            int filename_byteCount = 0;
+            if (filename != null)
+            {
+                filename_byteCount = Encoding.UTF8.GetByteCount(filename);
+                if (filename_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_filename = Util.Allocate(filename_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_filename_stackBytes = stackalloc byte[filename_byteCount + 1];
+                    native_filename = native_filename_stackBytes;
+                }
+                int native_filename_offset = Util.GetUtf8(filename, native_filename, filename_byteCount);
+                native_filename[native_filename_offset] = 0;
+            }
+            else { native_filename = null; }
+            ImFontConfig* native_font_cfg = font_cfg.NativePtr;
+            ushort* native_glyph_ranges = (ushort*)glyph_ranges.ToPointer();
+            ImFont* ret = ImGuiNative.ImFontAtlas_AddFontFromFileTTF((ImFontAtlas*)(NativePtr), native_filename, size_pixels, native_font_cfg, native_glyph_ranges);
+            if (filename_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_filename);
+            }
+            return new ImFontPtr(ret);
+        }
 #endif
+        public ImFontPtr AddFontFromFileTTF(string filename, float size_pixels, ImFontConfigPtr font_cfg, IntPtr glyph_ranges)
         {
             byte* native_filename;
             int filename_byteCount = 0;
@@ -260,9 +341,36 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public ImFontPtr AddFontFromMemoryCompressedBase85TTF(ReadOnlySpan<char> compressed_font_data_base85, float size_pixels)
-#else
-        public ImFontPtr AddFontFromMemoryCompressedBase85TTF(string compressed_font_data_base85, float size_pixels)
+        {
+            byte* native_compressed_font_data_base85;
+            int compressed_font_data_base85_byteCount = 0;
+            if (compressed_font_data_base85 != null)
+            {
+                compressed_font_data_base85_byteCount = Encoding.UTF8.GetByteCount(compressed_font_data_base85);
+                if (compressed_font_data_base85_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_compressed_font_data_base85 = Util.Allocate(compressed_font_data_base85_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_compressed_font_data_base85_stackBytes = stackalloc byte[compressed_font_data_base85_byteCount + 1];
+                    native_compressed_font_data_base85 = native_compressed_font_data_base85_stackBytes;
+                }
+                int native_compressed_font_data_base85_offset = Util.GetUtf8(compressed_font_data_base85, native_compressed_font_data_base85, compressed_font_data_base85_byteCount);
+                native_compressed_font_data_base85[native_compressed_font_data_base85_offset] = 0;
+            }
+            else { native_compressed_font_data_base85 = null; }
+            ImFontConfig* font_cfg = null;
+            ushort* glyph_ranges = null;
+            ImFont* ret = ImGuiNative.ImFontAtlas_AddFontFromMemoryCompressedBase85TTF((ImFontAtlas*)(NativePtr), native_compressed_font_data_base85, size_pixels, font_cfg, glyph_ranges);
+            if (compressed_font_data_base85_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_compressed_font_data_base85);
+            }
+            return new ImFontPtr(ret);
+        }
 #endif
+        public ImFontPtr AddFontFromMemoryCompressedBase85TTF(string compressed_font_data_base85, float size_pixels)
         {
             byte* native_compressed_font_data_base85;
             int compressed_font_data_base85_byteCount = 0;
@@ -293,9 +401,36 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public ImFontPtr AddFontFromMemoryCompressedBase85TTF(ReadOnlySpan<char> compressed_font_data_base85, float size_pixels, ImFontConfigPtr font_cfg)
-#else
-        public ImFontPtr AddFontFromMemoryCompressedBase85TTF(string compressed_font_data_base85, float size_pixels, ImFontConfigPtr font_cfg)
+        {
+            byte* native_compressed_font_data_base85;
+            int compressed_font_data_base85_byteCount = 0;
+            if (compressed_font_data_base85 != null)
+            {
+                compressed_font_data_base85_byteCount = Encoding.UTF8.GetByteCount(compressed_font_data_base85);
+                if (compressed_font_data_base85_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_compressed_font_data_base85 = Util.Allocate(compressed_font_data_base85_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_compressed_font_data_base85_stackBytes = stackalloc byte[compressed_font_data_base85_byteCount + 1];
+                    native_compressed_font_data_base85 = native_compressed_font_data_base85_stackBytes;
+                }
+                int native_compressed_font_data_base85_offset = Util.GetUtf8(compressed_font_data_base85, native_compressed_font_data_base85, compressed_font_data_base85_byteCount);
+                native_compressed_font_data_base85[native_compressed_font_data_base85_offset] = 0;
+            }
+            else { native_compressed_font_data_base85 = null; }
+            ImFontConfig* native_font_cfg = font_cfg.NativePtr;
+            ushort* glyph_ranges = null;
+            ImFont* ret = ImGuiNative.ImFontAtlas_AddFontFromMemoryCompressedBase85TTF((ImFontAtlas*)(NativePtr), native_compressed_font_data_base85, size_pixels, native_font_cfg, glyph_ranges);
+            if (compressed_font_data_base85_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_compressed_font_data_base85);
+            }
+            return new ImFontPtr(ret);
+        }
 #endif
+        public ImFontPtr AddFontFromMemoryCompressedBase85TTF(string compressed_font_data_base85, float size_pixels, ImFontConfigPtr font_cfg)
         {
             byte* native_compressed_font_data_base85;
             int compressed_font_data_base85_byteCount = 0;
@@ -326,9 +461,36 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public ImFontPtr AddFontFromMemoryCompressedBase85TTF(ReadOnlySpan<char> compressed_font_data_base85, float size_pixels, ImFontConfigPtr font_cfg, IntPtr glyph_ranges)
-#else
-        public ImFontPtr AddFontFromMemoryCompressedBase85TTF(string compressed_font_data_base85, float size_pixels, ImFontConfigPtr font_cfg, IntPtr glyph_ranges)
+        {
+            byte* native_compressed_font_data_base85;
+            int compressed_font_data_base85_byteCount = 0;
+            if (compressed_font_data_base85 != null)
+            {
+                compressed_font_data_base85_byteCount = Encoding.UTF8.GetByteCount(compressed_font_data_base85);
+                if (compressed_font_data_base85_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_compressed_font_data_base85 = Util.Allocate(compressed_font_data_base85_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_compressed_font_data_base85_stackBytes = stackalloc byte[compressed_font_data_base85_byteCount + 1];
+                    native_compressed_font_data_base85 = native_compressed_font_data_base85_stackBytes;
+                }
+                int native_compressed_font_data_base85_offset = Util.GetUtf8(compressed_font_data_base85, native_compressed_font_data_base85, compressed_font_data_base85_byteCount);
+                native_compressed_font_data_base85[native_compressed_font_data_base85_offset] = 0;
+            }
+            else { native_compressed_font_data_base85 = null; }
+            ImFontConfig* native_font_cfg = font_cfg.NativePtr;
+            ushort* native_glyph_ranges = (ushort*)glyph_ranges.ToPointer();
+            ImFont* ret = ImGuiNative.ImFontAtlas_AddFontFromMemoryCompressedBase85TTF((ImFontAtlas*)(NativePtr), native_compressed_font_data_base85, size_pixels, native_font_cfg, native_glyph_ranges);
+            if (compressed_font_data_base85_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_compressed_font_data_base85);
+            }
+            return new ImFontPtr(ret);
+        }
 #endif
+        public ImFontPtr AddFontFromMemoryCompressedBase85TTF(string compressed_font_data_base85, float size_pixels, ImFontConfigPtr font_cfg, IntPtr glyph_ranges)
         {
             byte* native_compressed_font_data_base85;
             int compressed_font_data_base85_byteCount = 0;

--- a/src/ImGui.NET/Generated/ImFontGlyphRangesBuilder.gen.cs
+++ b/src/ImGui.NET/Generated/ImFontGlyphRangesBuilder.gen.cs
@@ -29,9 +29,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public void AddText(ReadOnlySpan<char> text)
-#else
-        public void AddText(string text)
+        {
+            byte* native_text;
+            int text_byteCount = 0;
+            if (text != null)
+            {
+                text_byteCount = Encoding.UTF8.GetByteCount(text);
+                if (text_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_text = Util.Allocate(text_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_text_stackBytes = stackalloc byte[text_byteCount + 1];
+                    native_text = native_text_stackBytes;
+                }
+                int native_text_offset = Util.GetUtf8(text, native_text, text_byteCount);
+                native_text[native_text_offset] = 0;
+            }
+            else { native_text = null; }
+            byte* native_text_end = null;
+            ImGuiNative.ImFontGlyphRangesBuilder_AddText((ImFontGlyphRangesBuilder*)(NativePtr), native_text, native_text_end);
+            if (text_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_text);
+            }
+        }
 #endif
+        public void AddText(string text)
         {
             byte* native_text;
             int text_byteCount = 0;

--- a/src/ImGui.NET/Generated/ImGui.gen.cs
+++ b/src/ImGui.NET/Generated/ImGui.gen.cs
@@ -9,9 +9,35 @@ namespace ImGuiNET
     {
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static ImGuiPayloadPtr AcceptDragDropPayload(ReadOnlySpan<char> type)
-#else
-        public static ImGuiPayloadPtr AcceptDragDropPayload(string type)
+        {
+            byte* native_type;
+            int type_byteCount = 0;
+            if (type != null)
+            {
+                type_byteCount = Encoding.UTF8.GetByteCount(type);
+                if (type_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_type = Util.Allocate(type_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_type_stackBytes = stackalloc byte[type_byteCount + 1];
+                    native_type = native_type_stackBytes;
+                }
+                int native_type_offset = Util.GetUtf8(type, native_type, type_byteCount);
+                native_type[native_type_offset] = 0;
+            }
+            else { native_type = null; }
+            ImGuiDragDropFlags flags = (ImGuiDragDropFlags)0;
+            ImGuiPayload* ret = ImGuiNative.igAcceptDragDropPayload(native_type, flags);
+            if (type_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_type);
+            }
+            return new ImGuiPayloadPtr(ret);
+        }
 #endif
+        public static ImGuiPayloadPtr AcceptDragDropPayload(string type)
         {
             byte* native_type;
             int type_byteCount = 0;
@@ -41,9 +67,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static ImGuiPayloadPtr AcceptDragDropPayload(ReadOnlySpan<char> type, ImGuiDragDropFlags flags)
-#else
-        public static ImGuiPayloadPtr AcceptDragDropPayload(string type, ImGuiDragDropFlags flags)
+        {
+            byte* native_type;
+            int type_byteCount = 0;
+            if (type != null)
+            {
+                type_byteCount = Encoding.UTF8.GetByteCount(type);
+                if (type_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_type = Util.Allocate(type_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_type_stackBytes = stackalloc byte[type_byteCount + 1];
+                    native_type = native_type_stackBytes;
+                }
+                int native_type_offset = Util.GetUtf8(type, native_type, type_byteCount);
+                native_type[native_type_offset] = 0;
+            }
+            else { native_type = null; }
+            ImGuiPayload* ret = ImGuiNative.igAcceptDragDropPayload(native_type, flags);
+            if (type_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_type);
+            }
+            return new ImGuiPayloadPtr(ret);
+        }
 #endif
+        public static ImGuiPayloadPtr AcceptDragDropPayload(string type, ImGuiDragDropFlags flags)
         {
             byte* native_type;
             int type_byteCount = 0;
@@ -76,9 +127,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ArrowButton(ReadOnlySpan<char> str_id, ImGuiDir dir)
-#else
-        public static bool ArrowButton(string str_id, ImGuiDir dir)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            byte ret = ImGuiNative.igArrowButton(native_str_id, dir);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool ArrowButton(string str_id, ImGuiDir dir)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -107,9 +183,36 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Begin(ReadOnlySpan<char> name)
-#else
-        public static bool Begin(string name)
+        {
+            byte* native_name;
+            int name_byteCount = 0;
+            if (name != null)
+            {
+                name_byteCount = Encoding.UTF8.GetByteCount(name);
+                if (name_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_name = Util.Allocate(name_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_name_stackBytes = stackalloc byte[name_byteCount + 1];
+                    native_name = native_name_stackBytes;
+                }
+                int native_name_offset = Util.GetUtf8(name, native_name, name_byteCount);
+                native_name[native_name_offset] = 0;
+            }
+            else { native_name = null; }
+            byte* p_open = null;
+            ImGuiWindowFlags flags = (ImGuiWindowFlags)0;
+            byte ret = ImGuiNative.igBegin(native_name, p_open, flags);
+            if (name_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_name);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool Begin(string name)
         {
             byte* native_name;
             int name_byteCount = 0;
@@ -140,9 +243,38 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Begin(ReadOnlySpan<char> name, ref bool p_open)
-#else
-        public static bool Begin(string name, ref bool p_open)
+        {
+            byte* native_name;
+            int name_byteCount = 0;
+            if (name != null)
+            {
+                name_byteCount = Encoding.UTF8.GetByteCount(name);
+                if (name_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_name = Util.Allocate(name_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_name_stackBytes = stackalloc byte[name_byteCount + 1];
+                    native_name = native_name_stackBytes;
+                }
+                int native_name_offset = Util.GetUtf8(name, native_name, name_byteCount);
+                native_name[native_name_offset] = 0;
+            }
+            else { native_name = null; }
+            byte native_p_open_val = p_open ? (byte)1 : (byte)0;
+            byte* native_p_open = &native_p_open_val;
+            ImGuiWindowFlags flags = (ImGuiWindowFlags)0;
+            byte ret = ImGuiNative.igBegin(native_name, native_p_open, flags);
+            if (name_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_name);
+            }
+            p_open = native_p_open_val != 0;
+            return ret != 0;
+        }
 #endif
+        public static bool Begin(string name, ref bool p_open)
         {
             byte* native_name;
             int name_byteCount = 0;
@@ -175,9 +307,37 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Begin(ReadOnlySpan<char> name, ref bool p_open, ImGuiWindowFlags flags)
-#else
-        public static bool Begin(string name, ref bool p_open, ImGuiWindowFlags flags)
+        {
+            byte* native_name;
+            int name_byteCount = 0;
+            if (name != null)
+            {
+                name_byteCount = Encoding.UTF8.GetByteCount(name);
+                if (name_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_name = Util.Allocate(name_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_name_stackBytes = stackalloc byte[name_byteCount + 1];
+                    native_name = native_name_stackBytes;
+                }
+                int native_name_offset = Util.GetUtf8(name, native_name, name_byteCount);
+                native_name[native_name_offset] = 0;
+            }
+            else { native_name = null; }
+            byte native_p_open_val = p_open ? (byte)1 : (byte)0;
+            byte* native_p_open = &native_p_open_val;
+            byte ret = ImGuiNative.igBegin(native_name, native_p_open, flags);
+            if (name_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_name);
+            }
+            p_open = native_p_open_val != 0;
+            return ret != 0;
+        }
 #endif
+        public static bool Begin(string name, ref bool p_open, ImGuiWindowFlags flags)
         {
             byte* native_name;
             int name_byteCount = 0;
@@ -209,9 +369,37 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginChild(ReadOnlySpan<char> str_id)
-#else
-        public static bool BeginChild(string str_id)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            Vector2 size = new Vector2();
+            byte border = 0;
+            ImGuiWindowFlags flags = (ImGuiWindowFlags)0;
+            byte ret = ImGuiNative.igBeginChild_Str(native_str_id, size, border, flags);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool BeginChild(string str_id)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -243,9 +431,36 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginChild(ReadOnlySpan<char> str_id, Vector2 size)
-#else
-        public static bool BeginChild(string str_id, Vector2 size)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            byte border = 0;
+            ImGuiWindowFlags flags = (ImGuiWindowFlags)0;
+            byte ret = ImGuiNative.igBeginChild_Str(native_str_id, size, border, flags);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool BeginChild(string str_id, Vector2 size)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -276,9 +491,36 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginChild(ReadOnlySpan<char> str_id, Vector2 size, bool border)
-#else
-        public static bool BeginChild(string str_id, Vector2 size, bool border)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            byte native_border = border ? (byte)1 : (byte)0;
+            ImGuiWindowFlags flags = (ImGuiWindowFlags)0;
+            byte ret = ImGuiNative.igBeginChild_Str(native_str_id, size, native_border, flags);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool BeginChild(string str_id, Vector2 size, bool border)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -309,9 +551,35 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginChild(ReadOnlySpan<char> str_id, Vector2 size, bool border, ImGuiWindowFlags flags)
-#else
-        public static bool BeginChild(string str_id, Vector2 size, bool border, ImGuiWindowFlags flags)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            byte native_border = border ? (byte)1 : (byte)0;
+            byte ret = ImGuiNative.igBeginChild_Str(native_str_id, size, native_border, flags);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool BeginChild(string str_id, Vector2 size, bool border, ImGuiWindowFlags flags)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -380,9 +648,57 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginCombo(ReadOnlySpan<char> label, ReadOnlySpan<char> preview_value)
-#else
-        public static bool BeginCombo(string label, string preview_value)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_preview_value;
+            int preview_value_byteCount = 0;
+            if (preview_value != null)
+            {
+                preview_value_byteCount = Encoding.UTF8.GetByteCount(preview_value);
+                if (preview_value_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_preview_value = Util.Allocate(preview_value_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_preview_value_stackBytes = stackalloc byte[preview_value_byteCount + 1];
+                    native_preview_value = native_preview_value_stackBytes;
+                }
+                int native_preview_value_offset = Util.GetUtf8(preview_value, native_preview_value, preview_value_byteCount);
+                native_preview_value[native_preview_value_offset] = 0;
+            }
+            else { native_preview_value = null; }
+            ImGuiComboFlags flags = (ImGuiComboFlags)0;
+            byte ret = ImGuiNative.igBeginCombo(native_label, native_preview_value, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            if (preview_value_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_preview_value);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool BeginCombo(string label, string preview_value)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -434,9 +750,56 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginCombo(ReadOnlySpan<char> label, ReadOnlySpan<char> preview_value, ImGuiComboFlags flags)
-#else
-        public static bool BeginCombo(string label, string preview_value, ImGuiComboFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_preview_value;
+            int preview_value_byteCount = 0;
+            if (preview_value != null)
+            {
+                preview_value_byteCount = Encoding.UTF8.GetByteCount(preview_value);
+                if (preview_value_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_preview_value = Util.Allocate(preview_value_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_preview_value_stackBytes = stackalloc byte[preview_value_byteCount + 1];
+                    native_preview_value = native_preview_value_stackBytes;
+                }
+                int native_preview_value_offset = Util.GetUtf8(preview_value, native_preview_value, preview_value_byteCount);
+                native_preview_value[native_preview_value_offset] = 0;
+            }
+            else { native_preview_value = null; }
+            byte ret = ImGuiNative.igBeginCombo(native_label, native_preview_value, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            if (preview_value_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_preview_value);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool BeginCombo(string label, string preview_value, ImGuiComboFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -522,9 +885,35 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginListBox(ReadOnlySpan<char> label)
-#else
-        public static bool BeginListBox(string label)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            Vector2 size = new Vector2();
+            byte ret = ImGuiNative.igBeginListBox(native_label, size);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool BeginListBox(string label)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -554,9 +943,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginListBox(ReadOnlySpan<char> label, Vector2 size)
-#else
-        public static bool BeginListBox(string label, Vector2 size)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte ret = ImGuiNative.igBeginListBox(native_label, size);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool BeginListBox(string label, Vector2 size)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -590,9 +1004,35 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginMenu(ReadOnlySpan<char> label)
-#else
-        public static bool BeginMenu(string label)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte enabled = 1;
+            byte ret = ImGuiNative.igBeginMenu(native_label, enabled);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool BeginMenu(string label)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -622,9 +1062,35 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginMenu(ReadOnlySpan<char> label, bool enabled)
-#else
-        public static bool BeginMenu(string label, bool enabled)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte native_enabled = enabled ? (byte)1 : (byte)0;
+            byte ret = ImGuiNative.igBeginMenu(native_label, native_enabled);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool BeginMenu(string label, bool enabled)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -659,9 +1125,35 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginPopup(ReadOnlySpan<char> str_id)
-#else
-        public static bool BeginPopup(string str_id)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            ImGuiWindowFlags flags = (ImGuiWindowFlags)0;
+            byte ret = ImGuiNative.igBeginPopup(native_str_id, flags);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool BeginPopup(string str_id)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -691,9 +1183,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginPopup(ReadOnlySpan<char> str_id, ImGuiWindowFlags flags)
-#else
-        public static bool BeginPopup(string str_id, ImGuiWindowFlags flags)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            byte ret = ImGuiNative.igBeginPopup(native_str_id, flags);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool BeginPopup(string str_id, ImGuiWindowFlags flags)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -729,9 +1246,35 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginPopupContextItem(ReadOnlySpan<char> str_id)
-#else
-        public static bool BeginPopupContextItem(string str_id)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            ImGuiPopupFlags popup_flags = (ImGuiPopupFlags)1;
+            byte ret = ImGuiNative.igBeginPopupContextItem(native_str_id, popup_flags);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool BeginPopupContextItem(string str_id)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -761,9 +1304,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginPopupContextItem(ReadOnlySpan<char> str_id, ImGuiPopupFlags popup_flags)
-#else
-        public static bool BeginPopupContextItem(string str_id, ImGuiPopupFlags popup_flags)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            byte ret = ImGuiNative.igBeginPopupContextItem(native_str_id, popup_flags);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool BeginPopupContextItem(string str_id, ImGuiPopupFlags popup_flags)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -799,9 +1367,35 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginPopupContextVoid(ReadOnlySpan<char> str_id)
-#else
-        public static bool BeginPopupContextVoid(string str_id)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            ImGuiPopupFlags popup_flags = (ImGuiPopupFlags)1;
+            byte ret = ImGuiNative.igBeginPopupContextVoid(native_str_id, popup_flags);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool BeginPopupContextVoid(string str_id)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -831,9 +1425,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginPopupContextVoid(ReadOnlySpan<char> str_id, ImGuiPopupFlags popup_flags)
-#else
-        public static bool BeginPopupContextVoid(string str_id, ImGuiPopupFlags popup_flags)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            byte ret = ImGuiNative.igBeginPopupContextVoid(native_str_id, popup_flags);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool BeginPopupContextVoid(string str_id, ImGuiPopupFlags popup_flags)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -869,9 +1488,35 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginPopupContextWindow(ReadOnlySpan<char> str_id)
-#else
-        public static bool BeginPopupContextWindow(string str_id)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            ImGuiPopupFlags popup_flags = (ImGuiPopupFlags)1;
+            byte ret = ImGuiNative.igBeginPopupContextWindow(native_str_id, popup_flags);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool BeginPopupContextWindow(string str_id)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -901,9 +1546,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginPopupContextWindow(ReadOnlySpan<char> str_id, ImGuiPopupFlags popup_flags)
-#else
-        public static bool BeginPopupContextWindow(string str_id, ImGuiPopupFlags popup_flags)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            byte ret = ImGuiNative.igBeginPopupContextWindow(native_str_id, popup_flags);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool BeginPopupContextWindow(string str_id, ImGuiPopupFlags popup_flags)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -932,9 +1602,36 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginPopupModal(ReadOnlySpan<char> name)
-#else
-        public static bool BeginPopupModal(string name)
+        {
+            byte* native_name;
+            int name_byteCount = 0;
+            if (name != null)
+            {
+                name_byteCount = Encoding.UTF8.GetByteCount(name);
+                if (name_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_name = Util.Allocate(name_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_name_stackBytes = stackalloc byte[name_byteCount + 1];
+                    native_name = native_name_stackBytes;
+                }
+                int native_name_offset = Util.GetUtf8(name, native_name, name_byteCount);
+                native_name[native_name_offset] = 0;
+            }
+            else { native_name = null; }
+            byte* p_open = null;
+            ImGuiWindowFlags flags = (ImGuiWindowFlags)0;
+            byte ret = ImGuiNative.igBeginPopupModal(native_name, p_open, flags);
+            if (name_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_name);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool BeginPopupModal(string name)
         {
             byte* native_name;
             int name_byteCount = 0;
@@ -965,9 +1662,38 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginPopupModal(ReadOnlySpan<char> name, ref bool p_open)
-#else
-        public static bool BeginPopupModal(string name, ref bool p_open)
+        {
+            byte* native_name;
+            int name_byteCount = 0;
+            if (name != null)
+            {
+                name_byteCount = Encoding.UTF8.GetByteCount(name);
+                if (name_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_name = Util.Allocate(name_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_name_stackBytes = stackalloc byte[name_byteCount + 1];
+                    native_name = native_name_stackBytes;
+                }
+                int native_name_offset = Util.GetUtf8(name, native_name, name_byteCount);
+                native_name[native_name_offset] = 0;
+            }
+            else { native_name = null; }
+            byte native_p_open_val = p_open ? (byte)1 : (byte)0;
+            byte* native_p_open = &native_p_open_val;
+            ImGuiWindowFlags flags = (ImGuiWindowFlags)0;
+            byte ret = ImGuiNative.igBeginPopupModal(native_name, native_p_open, flags);
+            if (name_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_name);
+            }
+            p_open = native_p_open_val != 0;
+            return ret != 0;
+        }
 #endif
+        public static bool BeginPopupModal(string name, ref bool p_open)
         {
             byte* native_name;
             int name_byteCount = 0;
@@ -1000,9 +1726,37 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginPopupModal(ReadOnlySpan<char> name, ref bool p_open, ImGuiWindowFlags flags)
-#else
-        public static bool BeginPopupModal(string name, ref bool p_open, ImGuiWindowFlags flags)
+        {
+            byte* native_name;
+            int name_byteCount = 0;
+            if (name != null)
+            {
+                name_byteCount = Encoding.UTF8.GetByteCount(name);
+                if (name_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_name = Util.Allocate(name_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_name_stackBytes = stackalloc byte[name_byteCount + 1];
+                    native_name = native_name_stackBytes;
+                }
+                int native_name_offset = Util.GetUtf8(name, native_name, name_byteCount);
+                native_name[native_name_offset] = 0;
+            }
+            else { native_name = null; }
+            byte native_p_open_val = p_open ? (byte)1 : (byte)0;
+            byte* native_p_open = &native_p_open_val;
+            byte ret = ImGuiNative.igBeginPopupModal(native_name, native_p_open, flags);
+            if (name_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_name);
+            }
+            p_open = native_p_open_val != 0;
+            return ret != 0;
+        }
 #endif
+        public static bool BeginPopupModal(string name, ref bool p_open, ImGuiWindowFlags flags)
         {
             byte* native_name;
             int name_byteCount = 0;
@@ -1034,9 +1788,35 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginTabBar(ReadOnlySpan<char> str_id)
-#else
-        public static bool BeginTabBar(string str_id)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            ImGuiTabBarFlags flags = (ImGuiTabBarFlags)0;
+            byte ret = ImGuiNative.igBeginTabBar(native_str_id, flags);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool BeginTabBar(string str_id)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -1066,9 +1846,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginTabBar(ReadOnlySpan<char> str_id, ImGuiTabBarFlags flags)
-#else
-        public static bool BeginTabBar(string str_id, ImGuiTabBarFlags flags)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            byte ret = ImGuiNative.igBeginTabBar(native_str_id, flags);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool BeginTabBar(string str_id, ImGuiTabBarFlags flags)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -1097,9 +1902,36 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginTabItem(ReadOnlySpan<char> label)
-#else
-        public static bool BeginTabItem(string label)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* p_open = null;
+            ImGuiTabItemFlags flags = (ImGuiTabItemFlags)0;
+            byte ret = ImGuiNative.igBeginTabItem(native_label, p_open, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool BeginTabItem(string label)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -1130,9 +1962,38 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginTabItem(ReadOnlySpan<char> label, ref bool p_open)
-#else
-        public static bool BeginTabItem(string label, ref bool p_open)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte native_p_open_val = p_open ? (byte)1 : (byte)0;
+            byte* native_p_open = &native_p_open_val;
+            ImGuiTabItemFlags flags = (ImGuiTabItemFlags)0;
+            byte ret = ImGuiNative.igBeginTabItem(native_label, native_p_open, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            p_open = native_p_open_val != 0;
+            return ret != 0;
+        }
 #endif
+        public static bool BeginTabItem(string label, ref bool p_open)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -1165,9 +2026,37 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginTabItem(ReadOnlySpan<char> label, ref bool p_open, ImGuiTabItemFlags flags)
-#else
-        public static bool BeginTabItem(string label, ref bool p_open, ImGuiTabItemFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte native_p_open_val = p_open ? (byte)1 : (byte)0;
+            byte* native_p_open = &native_p_open_val;
+            byte ret = ImGuiNative.igBeginTabItem(native_label, native_p_open, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            p_open = native_p_open_val != 0;
+            return ret != 0;
+        }
 #endif
+        public static bool BeginTabItem(string label, ref bool p_open, ImGuiTabItemFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -1199,9 +2088,37 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginTable(ReadOnlySpan<char> str_id, int column)
-#else
-        public static bool BeginTable(string str_id, int column)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            ImGuiTableFlags flags = (ImGuiTableFlags)0;
+            Vector2 outer_size = new Vector2();
+            float inner_width = 0.0f;
+            byte ret = ImGuiNative.igBeginTable(native_str_id, column, flags, outer_size, inner_width);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool BeginTable(string str_id, int column)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -1233,9 +2150,36 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginTable(ReadOnlySpan<char> str_id, int column, ImGuiTableFlags flags)
-#else
-        public static bool BeginTable(string str_id, int column, ImGuiTableFlags flags)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            Vector2 outer_size = new Vector2();
+            float inner_width = 0.0f;
+            byte ret = ImGuiNative.igBeginTable(native_str_id, column, flags, outer_size, inner_width);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool BeginTable(string str_id, int column, ImGuiTableFlags flags)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -1266,9 +2210,35 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginTable(ReadOnlySpan<char> str_id, int column, ImGuiTableFlags flags, Vector2 outer_size)
-#else
-        public static bool BeginTable(string str_id, int column, ImGuiTableFlags flags, Vector2 outer_size)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            float inner_width = 0.0f;
+            byte ret = ImGuiNative.igBeginTable(native_str_id, column, flags, outer_size, inner_width);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool BeginTable(string str_id, int column, ImGuiTableFlags flags, Vector2 outer_size)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -1298,9 +2268,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool BeginTable(ReadOnlySpan<char> str_id, int column, ImGuiTableFlags flags, Vector2 outer_size, float inner_width)
-#else
-        public static bool BeginTable(string str_id, int column, ImGuiTableFlags flags, Vector2 outer_size, float inner_width)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            byte ret = ImGuiNative.igBeginTable(native_str_id, column, flags, outer_size, inner_width);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool BeginTable(string str_id, int column, ImGuiTableFlags flags, Vector2 outer_size, float inner_width)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -1338,9 +2333,33 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void BulletText(ReadOnlySpan<char> fmt)
-#else
-        public static void BulletText(string fmt)
+        {
+            byte* native_fmt;
+            int fmt_byteCount = 0;
+            if (fmt != null)
+            {
+                fmt_byteCount = Encoding.UTF8.GetByteCount(fmt);
+                if (fmt_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_fmt = Util.Allocate(fmt_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_fmt_stackBytes = stackalloc byte[fmt_byteCount + 1];
+                    native_fmt = native_fmt_stackBytes;
+                }
+                int native_fmt_offset = Util.GetUtf8(fmt, native_fmt, fmt_byteCount);
+                native_fmt[native_fmt_offset] = 0;
+            }
+            else { native_fmt = null; }
+            ImGuiNative.igBulletText(native_fmt);
+            if (fmt_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_fmt);
+            }
+        }
 #endif
+        public static void BulletText(string fmt)
         {
             byte* native_fmt;
             int fmt_byteCount = 0;
@@ -1368,9 +2387,35 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Button(ReadOnlySpan<char> label)
-#else
-        public static bool Button(string label)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            Vector2 size = new Vector2();
+            byte ret = ImGuiNative.igButton(native_label, size);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool Button(string label)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -1400,9 +2445,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Button(ReadOnlySpan<char> label, Vector2 size)
-#else
-        public static bool Button(string label, Vector2 size)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte ret = ImGuiNative.igButton(native_label, size);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool Button(string label, Vector2 size)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -1436,9 +2506,37 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Checkbox(ReadOnlySpan<char> label, ref bool v)
-#else
-        public static bool Checkbox(string label, ref bool v)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte native_v_val = v ? (byte)1 : (byte)0;
+            byte* native_v = &native_v_val;
+            byte ret = ImGuiNative.igCheckbox(native_label, native_v);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            v = native_v_val != 0;
+            return ret != 0;
+        }
 #endif
+        public static bool Checkbox(string label, ref bool v)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -1470,9 +2568,37 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool CheckboxFlags(ReadOnlySpan<char> label, ref int flags, int flags_value)
-#else
-        public static bool CheckboxFlags(string label, ref int flags, int flags_value)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            fixed (int* native_flags = &flags)
+            {
+                byte ret = ImGuiNative.igCheckboxFlags_IntPtr(native_label, native_flags, flags_value);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool CheckboxFlags(string label, ref int flags, int flags_value)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -1504,9 +2630,37 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool CheckboxFlags(ReadOnlySpan<char> label, ref uint flags, uint flags_value)
-#else
-        public static bool CheckboxFlags(string label, ref uint flags, uint flags_value)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            fixed (uint* native_flags = &flags)
+            {
+                byte ret = ImGuiNative.igCheckboxFlags_UintPtr(native_label, native_flags, flags_value);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool CheckboxFlags(string label, ref uint flags, uint flags_value)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -1542,9 +2696,35 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool CollapsingHeader(ReadOnlySpan<char> label)
-#else
-        public static bool CollapsingHeader(string label)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            ImGuiTreeNodeFlags flags = (ImGuiTreeNodeFlags)0;
+            byte ret = ImGuiNative.igCollapsingHeader_TreeNodeFlags(native_label, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool CollapsingHeader(string label)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -1574,9 +2754,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool CollapsingHeader(ReadOnlySpan<char> label, ImGuiTreeNodeFlags flags)
-#else
-        public static bool CollapsingHeader(string label, ImGuiTreeNodeFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte ret = ImGuiNative.igCollapsingHeader_TreeNodeFlags(native_label, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool CollapsingHeader(string label, ImGuiTreeNodeFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -1605,9 +2810,38 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool CollapsingHeader(ReadOnlySpan<char> label, ref bool p_visible)
-#else
-        public static bool CollapsingHeader(string label, ref bool p_visible)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte native_p_visible_val = p_visible ? (byte)1 : (byte)0;
+            byte* native_p_visible = &native_p_visible_val;
+            ImGuiTreeNodeFlags flags = (ImGuiTreeNodeFlags)0;
+            byte ret = ImGuiNative.igCollapsingHeader_BoolPtr(native_label, native_p_visible, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            p_visible = native_p_visible_val != 0;
+            return ret != 0;
+        }
 #endif
+        public static bool CollapsingHeader(string label, ref bool p_visible)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -1640,9 +2874,37 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool CollapsingHeader(ReadOnlySpan<char> label, ref bool p_visible, ImGuiTreeNodeFlags flags)
-#else
-        public static bool CollapsingHeader(string label, ref bool p_visible, ImGuiTreeNodeFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte native_p_visible_val = p_visible ? (byte)1 : (byte)0;
+            byte* native_p_visible = &native_p_visible_val;
+            byte ret = ImGuiNative.igCollapsingHeader_BoolPtr(native_label, native_p_visible, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            p_visible = native_p_visible_val != 0;
+            return ret != 0;
+        }
 #endif
+        public static bool CollapsingHeader(string label, ref bool p_visible, ImGuiTreeNodeFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -1674,9 +2936,36 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ColorButton(ReadOnlySpan<char> desc_id, Vector4 col)
-#else
-        public static bool ColorButton(string desc_id, Vector4 col)
+        {
+            byte* native_desc_id;
+            int desc_id_byteCount = 0;
+            if (desc_id != null)
+            {
+                desc_id_byteCount = Encoding.UTF8.GetByteCount(desc_id);
+                if (desc_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_desc_id = Util.Allocate(desc_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_desc_id_stackBytes = stackalloc byte[desc_id_byteCount + 1];
+                    native_desc_id = native_desc_id_stackBytes;
+                }
+                int native_desc_id_offset = Util.GetUtf8(desc_id, native_desc_id, desc_id_byteCount);
+                native_desc_id[native_desc_id_offset] = 0;
+            }
+            else { native_desc_id = null; }
+            ImGuiColorEditFlags flags = (ImGuiColorEditFlags)0;
+            Vector2 size = new Vector2();
+            byte ret = ImGuiNative.igColorButton(native_desc_id, col, flags, size);
+            if (desc_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_desc_id);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool ColorButton(string desc_id, Vector4 col)
         {
             byte* native_desc_id;
             int desc_id_byteCount = 0;
@@ -1707,9 +2996,35 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ColorButton(ReadOnlySpan<char> desc_id, Vector4 col, ImGuiColorEditFlags flags)
-#else
-        public static bool ColorButton(string desc_id, Vector4 col, ImGuiColorEditFlags flags)
+        {
+            byte* native_desc_id;
+            int desc_id_byteCount = 0;
+            if (desc_id != null)
+            {
+                desc_id_byteCount = Encoding.UTF8.GetByteCount(desc_id);
+                if (desc_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_desc_id = Util.Allocate(desc_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_desc_id_stackBytes = stackalloc byte[desc_id_byteCount + 1];
+                    native_desc_id = native_desc_id_stackBytes;
+                }
+                int native_desc_id_offset = Util.GetUtf8(desc_id, native_desc_id, desc_id_byteCount);
+                native_desc_id[native_desc_id_offset] = 0;
+            }
+            else { native_desc_id = null; }
+            Vector2 size = new Vector2();
+            byte ret = ImGuiNative.igColorButton(native_desc_id, col, flags, size);
+            if (desc_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_desc_id);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool ColorButton(string desc_id, Vector4 col, ImGuiColorEditFlags flags)
         {
             byte* native_desc_id;
             int desc_id_byteCount = 0;
@@ -1739,9 +3054,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ColorButton(ReadOnlySpan<char> desc_id, Vector4 col, ImGuiColorEditFlags flags, Vector2 size)
-#else
-        public static bool ColorButton(string desc_id, Vector4 col, ImGuiColorEditFlags flags, Vector2 size)
+        {
+            byte* native_desc_id;
+            int desc_id_byteCount = 0;
+            if (desc_id != null)
+            {
+                desc_id_byteCount = Encoding.UTF8.GetByteCount(desc_id);
+                if (desc_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_desc_id = Util.Allocate(desc_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_desc_id_stackBytes = stackalloc byte[desc_id_byteCount + 1];
+                    native_desc_id = native_desc_id_stackBytes;
+                }
+                int native_desc_id_offset = Util.GetUtf8(desc_id, native_desc_id, desc_id_byteCount);
+                native_desc_id[native_desc_id_offset] = 0;
+            }
+            else { native_desc_id = null; }
+            byte ret = ImGuiNative.igColorButton(native_desc_id, col, flags, size);
+            if (desc_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_desc_id);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool ColorButton(string desc_id, Vector4 col, ImGuiColorEditFlags flags, Vector2 size)
         {
             byte* native_desc_id;
             int desc_id_byteCount = 0;
@@ -1807,9 +3147,38 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ColorEdit3(ReadOnlySpan<char> label, ref Vector3 col)
-#else
-        public static bool ColorEdit3(string label, ref Vector3 col)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            ImGuiColorEditFlags flags = (ImGuiColorEditFlags)0;
+            fixed (Vector3* native_col = &col)
+            {
+                byte ret = ImGuiNative.igColorEdit3(native_label, native_col, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool ColorEdit3(string label, ref Vector3 col)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -1842,9 +3211,37 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ColorEdit3(ReadOnlySpan<char> label, ref Vector3 col, ImGuiColorEditFlags flags)
-#else
-        public static bool ColorEdit3(string label, ref Vector3 col, ImGuiColorEditFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            fixed (Vector3* native_col = &col)
+            {
+                byte ret = ImGuiNative.igColorEdit3(native_label, native_col, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool ColorEdit3(string label, ref Vector3 col, ImGuiColorEditFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -1876,9 +3273,38 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ColorEdit4(ReadOnlySpan<char> label, ref Vector4 col)
-#else
-        public static bool ColorEdit4(string label, ref Vector4 col)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            ImGuiColorEditFlags flags = (ImGuiColorEditFlags)0;
+            fixed (Vector4* native_col = &col)
+            {
+                byte ret = ImGuiNative.igColorEdit4(native_label, native_col, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool ColorEdit4(string label, ref Vector4 col)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -1911,9 +3337,37 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ColorEdit4(ReadOnlySpan<char> label, ref Vector4 col, ImGuiColorEditFlags flags)
-#else
-        public static bool ColorEdit4(string label, ref Vector4 col, ImGuiColorEditFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            fixed (Vector4* native_col = &col)
+            {
+                byte ret = ImGuiNative.igColorEdit4(native_label, native_col, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool ColorEdit4(string label, ref Vector4 col, ImGuiColorEditFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -1945,9 +3399,38 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ColorPicker3(ReadOnlySpan<char> label, ref Vector3 col)
-#else
-        public static bool ColorPicker3(string label, ref Vector3 col)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            ImGuiColorEditFlags flags = (ImGuiColorEditFlags)0;
+            fixed (Vector3* native_col = &col)
+            {
+                byte ret = ImGuiNative.igColorPicker3(native_label, native_col, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool ColorPicker3(string label, ref Vector3 col)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -1980,9 +3463,37 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ColorPicker3(ReadOnlySpan<char> label, ref Vector3 col, ImGuiColorEditFlags flags)
-#else
-        public static bool ColorPicker3(string label, ref Vector3 col, ImGuiColorEditFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            fixed (Vector3* native_col = &col)
+            {
+                byte ret = ImGuiNative.igColorPicker3(native_label, native_col, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool ColorPicker3(string label, ref Vector3 col, ImGuiColorEditFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -2014,9 +3525,39 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ColorPicker4(ReadOnlySpan<char> label, ref Vector4 col)
-#else
-        public static bool ColorPicker4(string label, ref Vector4 col)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            ImGuiColorEditFlags flags = (ImGuiColorEditFlags)0;
+            float* ref_col = null;
+            fixed (Vector4* native_col = &col)
+            {
+                byte ret = ImGuiNative.igColorPicker4(native_label, native_col, flags, ref_col);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool ColorPicker4(string label, ref Vector4 col)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -2050,9 +3591,38 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ColorPicker4(ReadOnlySpan<char> label, ref Vector4 col, ImGuiColorEditFlags flags)
-#else
-        public static bool ColorPicker4(string label, ref Vector4 col, ImGuiColorEditFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            float* ref_col = null;
+            fixed (Vector4* native_col = &col)
+            {
+                byte ret = ImGuiNative.igColorPicker4(native_label, native_col, flags, ref_col);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool ColorPicker4(string label, ref Vector4 col, ImGuiColorEditFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -2085,9 +3655,40 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ColorPicker4(ReadOnlySpan<char> label, ref Vector4 col, ImGuiColorEditFlags flags, ref float ref_col)
-#else
-        public static bool ColorPicker4(string label, ref Vector4 col, ImGuiColorEditFlags flags, ref float ref_col)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            fixed (Vector4* native_col = &col)
+            {
+                fixed (float* native_ref_col = &ref_col)
+                {
+                    byte ret = ImGuiNative.igColorPicker4(native_label, native_col, flags, native_ref_col);
+                    if (label_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_label);
+                    }
+                    return ret != 0;
+                }
+            }
+        }
 #endif
+        public static bool ColorPicker4(string label, ref Vector4 col, ImGuiColorEditFlags flags, ref float ref_col)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -2135,9 +3736,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void Columns(int count, ReadOnlySpan<char> id)
-#else
-        public static void Columns(int count, string id)
+        {
+            byte* native_id;
+            int id_byteCount = 0;
+            if (id != null)
+            {
+                id_byteCount = Encoding.UTF8.GetByteCount(id);
+                if (id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_id = Util.Allocate(id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_id_stackBytes = stackalloc byte[id_byteCount + 1];
+                    native_id = native_id_stackBytes;
+                }
+                int native_id_offset = Util.GetUtf8(id, native_id, id_byteCount);
+                native_id[native_id_offset] = 0;
+            }
+            else { native_id = null; }
+            byte border = 1;
+            ImGuiNative.igColumns(count, native_id, border);
+            if (id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_id);
+            }
+        }
 #endif
+        public static void Columns(int count, string id)
         {
             byte* native_id;
             int id_byteCount = 0;
@@ -2166,9 +3792,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void Columns(int count, ReadOnlySpan<char> id, bool border)
-#else
-        public static void Columns(int count, string id, bool border)
+        {
+            byte* native_id;
+            int id_byteCount = 0;
+            if (id != null)
+            {
+                id_byteCount = Encoding.UTF8.GetByteCount(id);
+                if (id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_id = Util.Allocate(id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_id_stackBytes = stackalloc byte[id_byteCount + 1];
+                    native_id = native_id_stackBytes;
+                }
+                int native_id_offset = Util.GetUtf8(id, native_id, id_byteCount);
+                native_id[native_id_offset] = 0;
+            }
+            else { native_id = null; }
+            byte native_border = border ? (byte)1 : (byte)0;
+            ImGuiNative.igColumns(count, native_id, native_border);
+            if (id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_id);
+            }
+        }
 #endif
+        public static void Columns(int count, string id, bool border)
         {
             byte* native_id;
             int id_byteCount = 0;
@@ -2197,9 +3848,65 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Combo(ReadOnlySpan<char> label, ref int current_item, string[] items, int items_count)
-#else
-        public static bool Combo(string label, ref int current_item, string[] items, int items_count)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            int* items_byteCounts = stackalloc int[items.Length];
+            int items_byteCount = 0;
+            for (int i = 0; i < items.Length; i++)
+            {
+                string s = items[i];
+                items_byteCounts[i] = Encoding.UTF8.GetByteCount(s);
+                items_byteCount += items_byteCounts[i] + 1;
+            }
+            byte* native_items_data = stackalloc byte[items_byteCount];
+            int offset = 0;
+            for (int i = 0; i < items.Length; i++)
+            {
+                string s = items[i];
+                fixed (char* sPtr = s)
+                {
+                    offset += Encoding.UTF8.GetBytes(sPtr, s.Length, native_items_data + offset, items_byteCounts[i]);
+                    native_items_data[offset] = 0;
+                    offset += 1;
+                }
+            }
+            byte** native_items = stackalloc byte*[items.Length];
+            offset = 0;
+            for (int i = 0; i < items.Length; i++)
+            {
+                native_items[i] = &native_items_data[offset];
+                offset += items_byteCounts[i] + 1;
+            }
+            int popup_max_height_in_items = -1;
+            fixed (int* native_current_item = &current_item)
+            {
+                byte ret = ImGuiNative.igCombo_Str_arr(native_label, native_current_item, native_items, items_count, popup_max_height_in_items);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool Combo(string label, ref int current_item, string[] items, int items_count)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -2259,9 +3966,64 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Combo(ReadOnlySpan<char> label, ref int current_item, string[] items, int items_count, int popup_max_height_in_items)
-#else
-        public static bool Combo(string label, ref int current_item, string[] items, int items_count, int popup_max_height_in_items)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            int* items_byteCounts = stackalloc int[items.Length];
+            int items_byteCount = 0;
+            for (int i = 0; i < items.Length; i++)
+            {
+                string s = items[i];
+                items_byteCounts[i] = Encoding.UTF8.GetByteCount(s);
+                items_byteCount += items_byteCounts[i] + 1;
+            }
+            byte* native_items_data = stackalloc byte[items_byteCount];
+            int offset = 0;
+            for (int i = 0; i < items.Length; i++)
+            {
+                string s = items[i];
+                fixed (char* sPtr = s)
+                {
+                    offset += Encoding.UTF8.GetBytes(sPtr, s.Length, native_items_data + offset, items_byteCounts[i]);
+                    native_items_data[offset] = 0;
+                    offset += 1;
+                }
+            }
+            byte** native_items = stackalloc byte*[items.Length];
+            offset = 0;
+            for (int i = 0; i < items.Length; i++)
+            {
+                native_items[i] = &native_items_data[offset];
+                offset += items_byteCounts[i] + 1;
+            }
+            fixed (int* native_current_item = &current_item)
+            {
+                byte ret = ImGuiNative.igCombo_Str_arr(native_label, native_current_item, native_items, items_count, popup_max_height_in_items);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool Combo(string label, ref int current_item, string[] items, int items_count, int popup_max_height_in_items)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -2320,9 +4082,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Combo(ReadOnlySpan<char> label, ref int current_item, ReadOnlySpan<char> items_separated_by_zeros)
-#else
-        public static bool Combo(string label, ref int current_item, string items_separated_by_zeros)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_items_separated_by_zeros;
+            int items_separated_by_zeros_byteCount = 0;
+            if (items_separated_by_zeros != null)
+            {
+                items_separated_by_zeros_byteCount = Encoding.UTF8.GetByteCount(items_separated_by_zeros);
+                if (items_separated_by_zeros_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_items_separated_by_zeros = Util.Allocate(items_separated_by_zeros_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_items_separated_by_zeros_stackBytes = stackalloc byte[items_separated_by_zeros_byteCount + 1];
+                    native_items_separated_by_zeros = native_items_separated_by_zeros_stackBytes;
+                }
+                int native_items_separated_by_zeros_offset = Util.GetUtf8(items_separated_by_zeros, native_items_separated_by_zeros, items_separated_by_zeros_byteCount);
+                native_items_separated_by_zeros[native_items_separated_by_zeros_offset] = 0;
+            }
+            else { native_items_separated_by_zeros = null; }
+            int popup_max_height_in_items = -1;
+            fixed (int* native_current_item = &current_item)
+            {
+                byte ret = ImGuiNative.igCombo_Str(native_label, native_current_item, native_items_separated_by_zeros, popup_max_height_in_items);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (items_separated_by_zeros_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_items_separated_by_zeros);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool Combo(string label, ref int current_item, string items_separated_by_zeros)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -2377,9 +4190,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Combo(ReadOnlySpan<char> label, ref int current_item, ReadOnlySpan<char> items_separated_by_zeros, int popup_max_height_in_items)
-#else
-        public static bool Combo(string label, ref int current_item, string items_separated_by_zeros, int popup_max_height_in_items)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_items_separated_by_zeros;
+            int items_separated_by_zeros_byteCount = 0;
+            if (items_separated_by_zeros != null)
+            {
+                items_separated_by_zeros_byteCount = Encoding.UTF8.GetByteCount(items_separated_by_zeros);
+                if (items_separated_by_zeros_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_items_separated_by_zeros = Util.Allocate(items_separated_by_zeros_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_items_separated_by_zeros_stackBytes = stackalloc byte[items_separated_by_zeros_byteCount + 1];
+                    native_items_separated_by_zeros = native_items_separated_by_zeros_stackBytes;
+                }
+                int native_items_separated_by_zeros_offset = Util.GetUtf8(items_separated_by_zeros, native_items_separated_by_zeros, items_separated_by_zeros_byteCount);
+                native_items_separated_by_zeros[native_items_separated_by_zeros_offset] = 0;
+            }
+            else { native_items_separated_by_zeros = null; }
+            fixed (int* native_current_item = &current_item)
+            {
+                byte ret = ImGuiNative.igCombo_Str(native_label, native_current_item, native_items_separated_by_zeros, popup_max_height_in_items);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (items_separated_by_zeros_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_items_separated_by_zeros);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool Combo(string label, ref int current_item, string items_separated_by_zeros, int popup_max_height_in_items)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -2445,9 +4308,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DebugCheckVersionAndDataLayout(ReadOnlySpan<char> version_str, uint sz_io, uint sz_style, uint sz_vec2, uint sz_vec4, uint sz_drawvert, uint sz_drawidx)
-#else
-        public static bool DebugCheckVersionAndDataLayout(string version_str, uint sz_io, uint sz_style, uint sz_vec2, uint sz_vec4, uint sz_drawvert, uint sz_drawidx)
+        {
+            byte* native_version_str;
+            int version_str_byteCount = 0;
+            if (version_str != null)
+            {
+                version_str_byteCount = Encoding.UTF8.GetByteCount(version_str);
+                if (version_str_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_version_str = Util.Allocate(version_str_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_version_str_stackBytes = stackalloc byte[version_str_byteCount + 1];
+                    native_version_str = native_version_str_stackBytes;
+                }
+                int native_version_str_offset = Util.GetUtf8(version_str, native_version_str, version_str_byteCount);
+                native_version_str[native_version_str_offset] = 0;
+            }
+            else { native_version_str = null; }
+            byte ret = ImGuiNative.igDebugCheckVersionAndDataLayout(native_version_str, sz_io, sz_style, sz_vec2, sz_vec4, sz_drawvert, sz_drawidx);
+            if (version_str_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_version_str);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool DebugCheckVersionAndDataLayout(string version_str, uint sz_io, uint sz_style, uint sz_vec2, uint sz_vec4, uint sz_drawvert, uint sz_drawidx)
         {
             byte* native_version_str;
             int version_str_byteCount = 0;
@@ -2476,9 +4364,33 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void DebugTextEncoding(ReadOnlySpan<char> text)
-#else
-        public static void DebugTextEncoding(string text)
+        {
+            byte* native_text;
+            int text_byteCount = 0;
+            if (text != null)
+            {
+                text_byteCount = Encoding.UTF8.GetByteCount(text);
+                if (text_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_text = Util.Allocate(text_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_text_stackBytes = stackalloc byte[text_byteCount + 1];
+                    native_text = native_text_stackBytes;
+                }
+                int native_text_offset = Util.GetUtf8(text, native_text, text_byteCount);
+                native_text[native_text_offset] = 0;
+            }
+            else { native_text = null; }
+            ImGuiNative.igDebugTextEncoding(native_text);
+            if (text_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_text);
+            }
+        }
 #endif
+        public static void DebugTextEncoding(string text)
         {
             byte* native_text;
             int text_byteCount = 0;
@@ -2576,9 +4488,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat(ReadOnlySpan<char> label, ref float v)
-#else
-        public static bool DragFloat(string label, ref float v)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            float v_speed = 1.0f;
+            float v_min = 0.0f;
+            float v_max = 0.0f;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.3f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (float* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragFloat(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragFloat(string label, ref float v)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -2632,9 +4594,58 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat(ReadOnlySpan<char> label, ref float v, float v_speed)
-#else
-        public static bool DragFloat(string label, ref float v, float v_speed)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            float v_min = 0.0f;
+            float v_max = 0.0f;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.3f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (float* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragFloat(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragFloat(string label, ref float v, float v_speed)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -2687,9 +4698,57 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat(ReadOnlySpan<char> label, ref float v, float v_speed, float v_min)
-#else
-        public static bool DragFloat(string label, ref float v, float v_speed, float v_min)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            float v_max = 0.0f;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.3f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (float* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragFloat(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragFloat(string label, ref float v, float v_speed, float v_min)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -2741,9 +4800,56 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat(ReadOnlySpan<char> label, ref float v, float v_speed, float v_min, float v_max)
-#else
-        public static bool DragFloat(string label, ref float v, float v_speed, float v_min, float v_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.3f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (float* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragFloat(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragFloat(string label, ref float v, float v_speed, float v_min, float v_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -2794,9 +4900,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat(ReadOnlySpan<char> label, ref float v, float v_speed, float v_min, float v_max, ReadOnlySpan<char> format)
-#else
-        public static bool DragFloat(string label, ref float v, float v_speed, float v_min, float v_max, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (float* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragFloat(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragFloat(string label, ref float v, float v_speed, float v_min, float v_max, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -2851,9 +5008,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat(ReadOnlySpan<char> label, ref float v, float v_speed, float v_min, float v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool DragFloat(string label, ref float v, float v_speed, float v_min, float v_max, string format, ImGuiSliderFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            fixed (float* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragFloat(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragFloat(string label, ref float v, float v_speed, float v_min, float v_max, string format, ImGuiSliderFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -2907,9 +5114,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat2(ReadOnlySpan<char> label, ref Vector2 v)
-#else
-        public static bool DragFloat2(string label, ref Vector2 v)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            float v_speed = 1.0f;
+            float v_min = 0.0f;
+            float v_max = 0.0f;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.3f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (Vector2* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragFloat2(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragFloat2(string label, ref Vector2 v)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -2963,9 +5220,58 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat2(ReadOnlySpan<char> label, ref Vector2 v, float v_speed)
-#else
-        public static bool DragFloat2(string label, ref Vector2 v, float v_speed)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            float v_min = 0.0f;
+            float v_max = 0.0f;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.3f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (Vector2* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragFloat2(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragFloat2(string label, ref Vector2 v, float v_speed)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -3018,9 +5324,57 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat2(ReadOnlySpan<char> label, ref Vector2 v, float v_speed, float v_min)
-#else
-        public static bool DragFloat2(string label, ref Vector2 v, float v_speed, float v_min)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            float v_max = 0.0f;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.3f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (Vector2* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragFloat2(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragFloat2(string label, ref Vector2 v, float v_speed, float v_min)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -3072,9 +5426,56 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat2(ReadOnlySpan<char> label, ref Vector2 v, float v_speed, float v_min, float v_max)
-#else
-        public static bool DragFloat2(string label, ref Vector2 v, float v_speed, float v_min, float v_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.3f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (Vector2* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragFloat2(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragFloat2(string label, ref Vector2 v, float v_speed, float v_min, float v_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -3125,9 +5526,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat2(ReadOnlySpan<char> label, ref Vector2 v, float v_speed, float v_min, float v_max, ReadOnlySpan<char> format)
-#else
-        public static bool DragFloat2(string label, ref Vector2 v, float v_speed, float v_min, float v_max, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (Vector2* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragFloat2(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragFloat2(string label, ref Vector2 v, float v_speed, float v_min, float v_max, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -3182,9 +5634,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat2(ReadOnlySpan<char> label, ref Vector2 v, float v_speed, float v_min, float v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool DragFloat2(string label, ref Vector2 v, float v_speed, float v_min, float v_max, string format, ImGuiSliderFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            fixed (Vector2* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragFloat2(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragFloat2(string label, ref Vector2 v, float v_speed, float v_min, float v_max, string format, ImGuiSliderFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -3238,9 +5740,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat3(ReadOnlySpan<char> label, ref Vector3 v)
-#else
-        public static bool DragFloat3(string label, ref Vector3 v)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            float v_speed = 1.0f;
+            float v_min = 0.0f;
+            float v_max = 0.0f;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.3f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (Vector3* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragFloat3(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragFloat3(string label, ref Vector3 v)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -3294,9 +5846,58 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat3(ReadOnlySpan<char> label, ref Vector3 v, float v_speed)
-#else
-        public static bool DragFloat3(string label, ref Vector3 v, float v_speed)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            float v_min = 0.0f;
+            float v_max = 0.0f;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.3f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (Vector3* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragFloat3(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragFloat3(string label, ref Vector3 v, float v_speed)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -3349,9 +5950,57 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat3(ReadOnlySpan<char> label, ref Vector3 v, float v_speed, float v_min)
-#else
-        public static bool DragFloat3(string label, ref Vector3 v, float v_speed, float v_min)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            float v_max = 0.0f;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.3f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (Vector3* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragFloat3(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragFloat3(string label, ref Vector3 v, float v_speed, float v_min)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -3403,9 +6052,56 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat3(ReadOnlySpan<char> label, ref Vector3 v, float v_speed, float v_min, float v_max)
-#else
-        public static bool DragFloat3(string label, ref Vector3 v, float v_speed, float v_min, float v_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.3f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (Vector3* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragFloat3(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragFloat3(string label, ref Vector3 v, float v_speed, float v_min, float v_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -3456,9 +6152,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat3(ReadOnlySpan<char> label, ref Vector3 v, float v_speed, float v_min, float v_max, ReadOnlySpan<char> format)
-#else
-        public static bool DragFloat3(string label, ref Vector3 v, float v_speed, float v_min, float v_max, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (Vector3* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragFloat3(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragFloat3(string label, ref Vector3 v, float v_speed, float v_min, float v_max, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -3513,9 +6260,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat3(ReadOnlySpan<char> label, ref Vector3 v, float v_speed, float v_min, float v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool DragFloat3(string label, ref Vector3 v, float v_speed, float v_min, float v_max, string format, ImGuiSliderFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            fixed (Vector3* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragFloat3(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragFloat3(string label, ref Vector3 v, float v_speed, float v_min, float v_max, string format, ImGuiSliderFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -3569,9 +6366,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat4(ReadOnlySpan<char> label, ref Vector4 v)
-#else
-        public static bool DragFloat4(string label, ref Vector4 v)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            float v_speed = 1.0f;
+            float v_min = 0.0f;
+            float v_max = 0.0f;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.3f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (Vector4* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragFloat4(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragFloat4(string label, ref Vector4 v)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -3625,9 +6472,58 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat4(ReadOnlySpan<char> label, ref Vector4 v, float v_speed)
-#else
-        public static bool DragFloat4(string label, ref Vector4 v, float v_speed)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            float v_min = 0.0f;
+            float v_max = 0.0f;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.3f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (Vector4* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragFloat4(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragFloat4(string label, ref Vector4 v, float v_speed)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -3680,9 +6576,57 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat4(ReadOnlySpan<char> label, ref Vector4 v, float v_speed, float v_min)
-#else
-        public static bool DragFloat4(string label, ref Vector4 v, float v_speed, float v_min)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            float v_max = 0.0f;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.3f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (Vector4* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragFloat4(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragFloat4(string label, ref Vector4 v, float v_speed, float v_min)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -3734,9 +6678,56 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat4(ReadOnlySpan<char> label, ref Vector4 v, float v_speed, float v_min, float v_max)
-#else
-        public static bool DragFloat4(string label, ref Vector4 v, float v_speed, float v_min, float v_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.3f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (Vector4* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragFloat4(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragFloat4(string label, ref Vector4 v, float v_speed, float v_min, float v_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -3787,9 +6778,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat4(ReadOnlySpan<char> label, ref Vector4 v, float v_speed, float v_min, float v_max, ReadOnlySpan<char> format)
-#else
-        public static bool DragFloat4(string label, ref Vector4 v, float v_speed, float v_min, float v_max, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (Vector4* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragFloat4(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragFloat4(string label, ref Vector4 v, float v_speed, float v_min, float v_max, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -3844,9 +6886,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloat4(ReadOnlySpan<char> label, ref Vector4 v, float v_speed, float v_min, float v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool DragFloat4(string label, ref Vector4 v, float v_speed, float v_min, float v_max, string format, ImGuiSliderFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            fixed (Vector4* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragFloat4(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragFloat4(string label, ref Vector4 v, float v_speed, float v_min, float v_max, string format, ImGuiSliderFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -3900,9 +6992,63 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloatRange2(ReadOnlySpan<char> label, ref float v_current_min, ref float v_current_max)
-#else
-        public static bool DragFloatRange2(string label, ref float v_current_min, ref float v_current_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            float v_speed = 1.0f;
+            float v_min = 0.0f;
+            float v_max = 0.0f;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.3f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            byte* native_format_max = null;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (float* native_v_current_min = &v_current_min)
+            {
+                fixed (float* native_v_current_max = &v_current_max)
+                {
+                    byte ret = ImGuiNative.igDragFloatRange2(native_label, native_v_current_min, native_v_current_max, v_speed, v_min, v_max, native_format, native_format_max, flags);
+                    if (label_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_label);
+                    }
+                    if (format_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_format);
+                    }
+                    return ret != 0;
+                }
+            }
+        }
 #endif
+        public static bool DragFloatRange2(string label, ref float v_current_min, ref float v_current_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -3960,9 +7106,62 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloatRange2(ReadOnlySpan<char> label, ref float v_current_min, ref float v_current_max, float v_speed)
-#else
-        public static bool DragFloatRange2(string label, ref float v_current_min, ref float v_current_max, float v_speed)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            float v_min = 0.0f;
+            float v_max = 0.0f;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.3f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            byte* native_format_max = null;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (float* native_v_current_min = &v_current_min)
+            {
+                fixed (float* native_v_current_max = &v_current_max)
+                {
+                    byte ret = ImGuiNative.igDragFloatRange2(native_label, native_v_current_min, native_v_current_max, v_speed, v_min, v_max, native_format, native_format_max, flags);
+                    if (label_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_label);
+                    }
+                    if (format_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_format);
+                    }
+                    return ret != 0;
+                }
+            }
+        }
 #endif
+        public static bool DragFloatRange2(string label, ref float v_current_min, ref float v_current_max, float v_speed)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -4019,9 +7218,61 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloatRange2(ReadOnlySpan<char> label, ref float v_current_min, ref float v_current_max, float v_speed, float v_min)
-#else
-        public static bool DragFloatRange2(string label, ref float v_current_min, ref float v_current_max, float v_speed, float v_min)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            float v_max = 0.0f;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.3f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            byte* native_format_max = null;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (float* native_v_current_min = &v_current_min)
+            {
+                fixed (float* native_v_current_max = &v_current_max)
+                {
+                    byte ret = ImGuiNative.igDragFloatRange2(native_label, native_v_current_min, native_v_current_max, v_speed, v_min, v_max, native_format, native_format_max, flags);
+                    if (label_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_label);
+                    }
+                    if (format_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_format);
+                    }
+                    return ret != 0;
+                }
+            }
+        }
 #endif
+        public static bool DragFloatRange2(string label, ref float v_current_min, ref float v_current_max, float v_speed, float v_min)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -4077,9 +7328,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloatRange2(ReadOnlySpan<char> label, ref float v_current_min, ref float v_current_max, float v_speed, float v_min, float v_max)
-#else
-        public static bool DragFloatRange2(string label, ref float v_current_min, ref float v_current_max, float v_speed, float v_min, float v_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.3f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            byte* native_format_max = null;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (float* native_v_current_min = &v_current_min)
+            {
+                fixed (float* native_v_current_max = &v_current_max)
+                {
+                    byte ret = ImGuiNative.igDragFloatRange2(native_label, native_v_current_min, native_v_current_max, v_speed, v_min, v_max, native_format, native_format_max, flags);
+                    if (label_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_label);
+                    }
+                    if (format_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_format);
+                    }
+                    return ret != 0;
+                }
+            }
+        }
 #endif
+        public static bool DragFloatRange2(string label, ref float v_current_min, ref float v_current_max, float v_speed, float v_min, float v_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -4134,9 +7436,64 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloatRange2(ReadOnlySpan<char> label, ref float v_current_min, ref float v_current_max, float v_speed, float v_min, float v_max, ReadOnlySpan<char> format)
-#else
-        public static bool DragFloatRange2(string label, ref float v_current_min, ref float v_current_max, float v_speed, float v_min, float v_max, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            byte* native_format_max = null;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (float* native_v_current_min = &v_current_min)
+            {
+                fixed (float* native_v_current_max = &v_current_max)
+                {
+                    byte ret = ImGuiNative.igDragFloatRange2(native_label, native_v_current_min, native_v_current_max, v_speed, v_min, v_max, native_format, native_format_max, flags);
+                    if (label_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_label);
+                    }
+                    if (format_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_format);
+                    }
+                    return ret != 0;
+                }
+            }
+        }
 #endif
+        public static bool DragFloatRange2(string label, ref float v_current_min, ref float v_current_max, float v_speed, float v_min, float v_max, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -4195,9 +7552,85 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloatRange2(ReadOnlySpan<char> label, ref float v_current_min, ref float v_current_max, float v_speed, float v_min, float v_max, ReadOnlySpan<char> format, ReadOnlySpan<char> format_max)
-#else
-        public static bool DragFloatRange2(string label, ref float v_current_min, ref float v_current_max, float v_speed, float v_min, float v_max, string format, string format_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            byte* native_format_max;
+            int format_max_byteCount = 0;
+            if (format_max != null)
+            {
+                format_max_byteCount = Encoding.UTF8.GetByteCount(format_max);
+                if (format_max_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format_max = Util.Allocate(format_max_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_max_stackBytes = stackalloc byte[format_max_byteCount + 1];
+                    native_format_max = native_format_max_stackBytes;
+                }
+                int native_format_max_offset = Util.GetUtf8(format_max, native_format_max, format_max_byteCount);
+                native_format_max[native_format_max_offset] = 0;
+            }
+            else { native_format_max = null; }
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (float* native_v_current_min = &v_current_min)
+            {
+                fixed (float* native_v_current_max = &v_current_max)
+                {
+                    byte ret = ImGuiNative.igDragFloatRange2(native_label, native_v_current_min, native_v_current_max, v_speed, v_min, v_max, native_format, native_format_max, flags);
+                    if (label_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_label);
+                    }
+                    if (format_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_format);
+                    }
+                    if (format_max_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_format_max);
+                    }
+                    return ret != 0;
+                }
+            }
+        }
 #endif
+        public static bool DragFloatRange2(string label, ref float v_current_min, ref float v_current_max, float v_speed, float v_min, float v_max, string format, string format_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -4277,9 +7710,84 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragFloatRange2(ReadOnlySpan<char> label, ref float v_current_min, ref float v_current_max, float v_speed, float v_min, float v_max, ReadOnlySpan<char> format, ReadOnlySpan<char> format_max, ImGuiSliderFlags flags)
-#else
-        public static bool DragFloatRange2(string label, ref float v_current_min, ref float v_current_max, float v_speed, float v_min, float v_max, string format, string format_max, ImGuiSliderFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            byte* native_format_max;
+            int format_max_byteCount = 0;
+            if (format_max != null)
+            {
+                format_max_byteCount = Encoding.UTF8.GetByteCount(format_max);
+                if (format_max_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format_max = Util.Allocate(format_max_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_max_stackBytes = stackalloc byte[format_max_byteCount + 1];
+                    native_format_max = native_format_max_stackBytes;
+                }
+                int native_format_max_offset = Util.GetUtf8(format_max, native_format_max, format_max_byteCount);
+                native_format_max[native_format_max_offset] = 0;
+            }
+            else { native_format_max = null; }
+            fixed (float* native_v_current_min = &v_current_min)
+            {
+                fixed (float* native_v_current_max = &v_current_max)
+                {
+                    byte ret = ImGuiNative.igDragFloatRange2(native_label, native_v_current_min, native_v_current_max, v_speed, v_min, v_max, native_format, native_format_max, flags);
+                    if (label_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_label);
+                    }
+                    if (format_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_format);
+                    }
+                    if (format_max_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_format_max);
+                    }
+                    return ret != 0;
+                }
+            }
+        }
 #endif
+        public static bool DragFloatRange2(string label, ref float v_current_min, ref float v_current_max, float v_speed, float v_min, float v_max, string format, string format_max, ImGuiSliderFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -4358,9 +7866,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt(ReadOnlySpan<char> label, ref int v)
-#else
-        public static bool DragInt(string label, ref int v)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            float v_speed = 1.0f;
+            int v_min = 0;
+            int v_max = 0;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%d", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragInt(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragInt(string label, ref int v)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -4414,9 +7972,58 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt(ReadOnlySpan<char> label, ref int v, float v_speed)
-#else
-        public static bool DragInt(string label, ref int v, float v_speed)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            int v_min = 0;
+            int v_max = 0;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%d", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragInt(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragInt(string label, ref int v, float v_speed)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -4469,9 +8076,57 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min)
-#else
-        public static bool DragInt(string label, ref int v, float v_speed, int v_min)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            int v_max = 0;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%d", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragInt(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragInt(string label, ref int v, float v_speed, int v_min)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -4523,9 +8178,56 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min, int v_max)
-#else
-        public static bool DragInt(string label, ref int v, float v_speed, int v_min, int v_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%d", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragInt(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragInt(string label, ref int v, float v_speed, int v_min, int v_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -4576,9 +8278,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min, int v_max, ReadOnlySpan<char> format)
-#else
-        public static bool DragInt(string label, ref int v, float v_speed, int v_min, int v_max, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragInt(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragInt(string label, ref int v, float v_speed, int v_min, int v_max, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -4633,9 +8386,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min, int v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool DragInt(string label, ref int v, float v_speed, int v_min, int v_max, string format, ImGuiSliderFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragInt(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragInt(string label, ref int v, float v_speed, int v_min, int v_max, string format, ImGuiSliderFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -4689,9 +8492,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt2(ReadOnlySpan<char> label, ref int v)
-#else
-        public static bool DragInt2(string label, ref int v)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            float v_speed = 1.0f;
+            int v_min = 0;
+            int v_max = 0;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%d", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragInt2(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragInt2(string label, ref int v)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -4745,9 +8598,58 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt2(ReadOnlySpan<char> label, ref int v, float v_speed)
-#else
-        public static bool DragInt2(string label, ref int v, float v_speed)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            int v_min = 0;
+            int v_max = 0;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%d", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragInt2(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragInt2(string label, ref int v, float v_speed)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -4800,9 +8702,57 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt2(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min)
-#else
-        public static bool DragInt2(string label, ref int v, float v_speed, int v_min)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            int v_max = 0;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%d", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragInt2(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragInt2(string label, ref int v, float v_speed, int v_min)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -4854,9 +8804,56 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt2(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min, int v_max)
-#else
-        public static bool DragInt2(string label, ref int v, float v_speed, int v_min, int v_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%d", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragInt2(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragInt2(string label, ref int v, float v_speed, int v_min, int v_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -4907,9 +8904,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt2(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min, int v_max, ReadOnlySpan<char> format)
-#else
-        public static bool DragInt2(string label, ref int v, float v_speed, int v_min, int v_max, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragInt2(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragInt2(string label, ref int v, float v_speed, int v_min, int v_max, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -4964,9 +9012,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt2(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min, int v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool DragInt2(string label, ref int v, float v_speed, int v_min, int v_max, string format, ImGuiSliderFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragInt2(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragInt2(string label, ref int v, float v_speed, int v_min, int v_max, string format, ImGuiSliderFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -5020,9 +9118,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt3(ReadOnlySpan<char> label, ref int v)
-#else
-        public static bool DragInt3(string label, ref int v)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            float v_speed = 1.0f;
+            int v_min = 0;
+            int v_max = 0;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%d", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragInt3(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragInt3(string label, ref int v)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -5076,9 +9224,58 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt3(ReadOnlySpan<char> label, ref int v, float v_speed)
-#else
-        public static bool DragInt3(string label, ref int v, float v_speed)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            int v_min = 0;
+            int v_max = 0;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%d", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragInt3(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragInt3(string label, ref int v, float v_speed)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -5131,9 +9328,57 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt3(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min)
-#else
-        public static bool DragInt3(string label, ref int v, float v_speed, int v_min)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            int v_max = 0;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%d", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragInt3(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragInt3(string label, ref int v, float v_speed, int v_min)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -5185,9 +9430,56 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt3(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min, int v_max)
-#else
-        public static bool DragInt3(string label, ref int v, float v_speed, int v_min, int v_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%d", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragInt3(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragInt3(string label, ref int v, float v_speed, int v_min, int v_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -5238,9 +9530,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt3(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min, int v_max, ReadOnlySpan<char> format)
-#else
-        public static bool DragInt3(string label, ref int v, float v_speed, int v_min, int v_max, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragInt3(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragInt3(string label, ref int v, float v_speed, int v_min, int v_max, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -5295,9 +9638,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt3(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min, int v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool DragInt3(string label, ref int v, float v_speed, int v_min, int v_max, string format, ImGuiSliderFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragInt3(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragInt3(string label, ref int v, float v_speed, int v_min, int v_max, string format, ImGuiSliderFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -5351,9 +9744,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt4(ReadOnlySpan<char> label, ref int v)
-#else
-        public static bool DragInt4(string label, ref int v)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            float v_speed = 1.0f;
+            int v_min = 0;
+            int v_max = 0;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%d", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragInt4(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragInt4(string label, ref int v)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -5407,9 +9850,58 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt4(ReadOnlySpan<char> label, ref int v, float v_speed)
-#else
-        public static bool DragInt4(string label, ref int v, float v_speed)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            int v_min = 0;
+            int v_max = 0;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%d", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragInt4(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragInt4(string label, ref int v, float v_speed)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -5462,9 +9954,57 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt4(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min)
-#else
-        public static bool DragInt4(string label, ref int v, float v_speed, int v_min)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            int v_max = 0;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%d", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragInt4(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragInt4(string label, ref int v, float v_speed, int v_min)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -5516,9 +10056,56 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt4(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min, int v_max)
-#else
-        public static bool DragInt4(string label, ref int v, float v_speed, int v_min, int v_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%d", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragInt4(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragInt4(string label, ref int v, float v_speed, int v_min, int v_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -5569,9 +10156,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt4(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min, int v_max, ReadOnlySpan<char> format)
-#else
-        public static bool DragInt4(string label, ref int v, float v_speed, int v_min, int v_max, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragInt4(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragInt4(string label, ref int v, float v_speed, int v_min, int v_max, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -5626,9 +10264,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragInt4(ReadOnlySpan<char> label, ref int v, float v_speed, int v_min, int v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool DragInt4(string label, ref int v, float v_speed, int v_min, int v_max, string format, ImGuiSliderFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igDragInt4(native_label, native_v, v_speed, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool DragInt4(string label, ref int v, float v_speed, int v_min, int v_max, string format, ImGuiSliderFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -5682,9 +10370,63 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragIntRange2(ReadOnlySpan<char> label, ref int v_current_min, ref int v_current_max)
-#else
-        public static bool DragIntRange2(string label, ref int v_current_min, ref int v_current_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            float v_speed = 1.0f;
+            int v_min = 0;
+            int v_max = 0;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%d", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            byte* native_format_max = null;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v_current_min = &v_current_min)
+            {
+                fixed (int* native_v_current_max = &v_current_max)
+                {
+                    byte ret = ImGuiNative.igDragIntRange2(native_label, native_v_current_min, native_v_current_max, v_speed, v_min, v_max, native_format, native_format_max, flags);
+                    if (label_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_label);
+                    }
+                    if (format_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_format);
+                    }
+                    return ret != 0;
+                }
+            }
+        }
 #endif
+        public static bool DragIntRange2(string label, ref int v_current_min, ref int v_current_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -5742,9 +10484,62 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragIntRange2(ReadOnlySpan<char> label, ref int v_current_min, ref int v_current_max, float v_speed)
-#else
-        public static bool DragIntRange2(string label, ref int v_current_min, ref int v_current_max, float v_speed)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            int v_min = 0;
+            int v_max = 0;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%d", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            byte* native_format_max = null;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v_current_min = &v_current_min)
+            {
+                fixed (int* native_v_current_max = &v_current_max)
+                {
+                    byte ret = ImGuiNative.igDragIntRange2(native_label, native_v_current_min, native_v_current_max, v_speed, v_min, v_max, native_format, native_format_max, flags);
+                    if (label_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_label);
+                    }
+                    if (format_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_format);
+                    }
+                    return ret != 0;
+                }
+            }
+        }
 #endif
+        public static bool DragIntRange2(string label, ref int v_current_min, ref int v_current_max, float v_speed)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -5801,9 +10596,61 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragIntRange2(ReadOnlySpan<char> label, ref int v_current_min, ref int v_current_max, float v_speed, int v_min)
-#else
-        public static bool DragIntRange2(string label, ref int v_current_min, ref int v_current_max, float v_speed, int v_min)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            int v_max = 0;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%d", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            byte* native_format_max = null;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v_current_min = &v_current_min)
+            {
+                fixed (int* native_v_current_max = &v_current_max)
+                {
+                    byte ret = ImGuiNative.igDragIntRange2(native_label, native_v_current_min, native_v_current_max, v_speed, v_min, v_max, native_format, native_format_max, flags);
+                    if (label_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_label);
+                    }
+                    if (format_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_format);
+                    }
+                    return ret != 0;
+                }
+            }
+        }
 #endif
+        public static bool DragIntRange2(string label, ref int v_current_min, ref int v_current_max, float v_speed, int v_min)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -5859,9 +10706,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragIntRange2(ReadOnlySpan<char> label, ref int v_current_min, ref int v_current_max, float v_speed, int v_min, int v_max)
-#else
-        public static bool DragIntRange2(string label, ref int v_current_min, ref int v_current_max, float v_speed, int v_min, int v_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%d", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            byte* native_format_max = null;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v_current_min = &v_current_min)
+            {
+                fixed (int* native_v_current_max = &v_current_max)
+                {
+                    byte ret = ImGuiNative.igDragIntRange2(native_label, native_v_current_min, native_v_current_max, v_speed, v_min, v_max, native_format, native_format_max, flags);
+                    if (label_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_label);
+                    }
+                    if (format_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_format);
+                    }
+                    return ret != 0;
+                }
+            }
+        }
 #endif
+        public static bool DragIntRange2(string label, ref int v_current_min, ref int v_current_max, float v_speed, int v_min, int v_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -5916,9 +10814,64 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragIntRange2(ReadOnlySpan<char> label, ref int v_current_min, ref int v_current_max, float v_speed, int v_min, int v_max, ReadOnlySpan<char> format)
-#else
-        public static bool DragIntRange2(string label, ref int v_current_min, ref int v_current_max, float v_speed, int v_min, int v_max, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            byte* native_format_max = null;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v_current_min = &v_current_min)
+            {
+                fixed (int* native_v_current_max = &v_current_max)
+                {
+                    byte ret = ImGuiNative.igDragIntRange2(native_label, native_v_current_min, native_v_current_max, v_speed, v_min, v_max, native_format, native_format_max, flags);
+                    if (label_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_label);
+                    }
+                    if (format_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_format);
+                    }
+                    return ret != 0;
+                }
+            }
+        }
 #endif
+        public static bool DragIntRange2(string label, ref int v_current_min, ref int v_current_max, float v_speed, int v_min, int v_max, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -5977,9 +10930,85 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragIntRange2(ReadOnlySpan<char> label, ref int v_current_min, ref int v_current_max, float v_speed, int v_min, int v_max, ReadOnlySpan<char> format, ReadOnlySpan<char> format_max)
-#else
-        public static bool DragIntRange2(string label, ref int v_current_min, ref int v_current_max, float v_speed, int v_min, int v_max, string format, string format_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            byte* native_format_max;
+            int format_max_byteCount = 0;
+            if (format_max != null)
+            {
+                format_max_byteCount = Encoding.UTF8.GetByteCount(format_max);
+                if (format_max_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format_max = Util.Allocate(format_max_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_max_stackBytes = stackalloc byte[format_max_byteCount + 1];
+                    native_format_max = native_format_max_stackBytes;
+                }
+                int native_format_max_offset = Util.GetUtf8(format_max, native_format_max, format_max_byteCount);
+                native_format_max[native_format_max_offset] = 0;
+            }
+            else { native_format_max = null; }
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v_current_min = &v_current_min)
+            {
+                fixed (int* native_v_current_max = &v_current_max)
+                {
+                    byte ret = ImGuiNative.igDragIntRange2(native_label, native_v_current_min, native_v_current_max, v_speed, v_min, v_max, native_format, native_format_max, flags);
+                    if (label_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_label);
+                    }
+                    if (format_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_format);
+                    }
+                    if (format_max_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_format_max);
+                    }
+                    return ret != 0;
+                }
+            }
+        }
 #endif
+        public static bool DragIntRange2(string label, ref int v_current_min, ref int v_current_max, float v_speed, int v_min, int v_max, string format, string format_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -6059,9 +11088,84 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragIntRange2(ReadOnlySpan<char> label, ref int v_current_min, ref int v_current_max, float v_speed, int v_min, int v_max, ReadOnlySpan<char> format, ReadOnlySpan<char> format_max, ImGuiSliderFlags flags)
-#else
-        public static bool DragIntRange2(string label, ref int v_current_min, ref int v_current_max, float v_speed, int v_min, int v_max, string format, string format_max, ImGuiSliderFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            byte* native_format_max;
+            int format_max_byteCount = 0;
+            if (format_max != null)
+            {
+                format_max_byteCount = Encoding.UTF8.GetByteCount(format_max);
+                if (format_max_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format_max = Util.Allocate(format_max_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_max_stackBytes = stackalloc byte[format_max_byteCount + 1];
+                    native_format_max = native_format_max_stackBytes;
+                }
+                int native_format_max_offset = Util.GetUtf8(format_max, native_format_max, format_max_byteCount);
+                native_format_max[native_format_max_offset] = 0;
+            }
+            else { native_format_max = null; }
+            fixed (int* native_v_current_min = &v_current_min)
+            {
+                fixed (int* native_v_current_max = &v_current_max)
+                {
+                    byte ret = ImGuiNative.igDragIntRange2(native_label, native_v_current_min, native_v_current_max, v_speed, v_min, v_max, native_format, native_format_max, flags);
+                    if (label_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_label);
+                    }
+                    if (format_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_format);
+                    }
+                    if (format_max_byteCount > Util.StackAllocationSizeLimit)
+                    {
+                        Util.Free(native_format_max);
+                    }
+                    return ret != 0;
+                }
+            }
+        }
 #endif
+        public static bool DragIntRange2(string label, ref int v_current_min, ref int v_current_max, float v_speed, int v_min, int v_max, string format, string format_max, ImGuiSliderFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -6140,9 +11244,40 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragScalar(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data)
-#else
-        public static bool DragScalar(string label, ImGuiDataType data_type, IntPtr p_data)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            void* native_p_data = (void*)p_data.ToPointer();
+            float v_speed = 1.0f;
+            void* p_min = null;
+            void* p_max = null;
+            byte* native_format = null;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            byte ret = ImGuiNative.igDragScalar(native_label, data_type, native_p_data, v_speed, p_min, p_max, native_format, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool DragScalar(string label, ImGuiDataType data_type, IntPtr p_data)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -6177,9 +11312,39 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragScalar(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, float v_speed)
-#else
-        public static bool DragScalar(string label, ImGuiDataType data_type, IntPtr p_data, float v_speed)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            void* native_p_data = (void*)p_data.ToPointer();
+            void* p_min = null;
+            void* p_max = null;
+            byte* native_format = null;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            byte ret = ImGuiNative.igDragScalar(native_label, data_type, native_p_data, v_speed, p_min, p_max, native_format, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool DragScalar(string label, ImGuiDataType data_type, IntPtr p_data, float v_speed)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -6213,9 +11378,39 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragScalar(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, float v_speed, IntPtr p_min)
-#else
-        public static bool DragScalar(string label, ImGuiDataType data_type, IntPtr p_data, float v_speed, IntPtr p_min)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            void* native_p_data = (void*)p_data.ToPointer();
+            void* native_p_min = (void*)p_min.ToPointer();
+            void* p_max = null;
+            byte* native_format = null;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            byte ret = ImGuiNative.igDragScalar(native_label, data_type, native_p_data, v_speed, native_p_min, p_max, native_format, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool DragScalar(string label, ImGuiDataType data_type, IntPtr p_data, float v_speed, IntPtr p_min)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -6249,9 +11444,39 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragScalar(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, float v_speed, IntPtr p_min, IntPtr p_max)
-#else
-        public static bool DragScalar(string label, ImGuiDataType data_type, IntPtr p_data, float v_speed, IntPtr p_min, IntPtr p_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            void* native_p_data = (void*)p_data.ToPointer();
+            void* native_p_min = (void*)p_min.ToPointer();
+            void* native_p_max = (void*)p_max.ToPointer();
+            byte* native_format = null;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            byte ret = ImGuiNative.igDragScalar(native_label, data_type, native_p_data, v_speed, native_p_min, native_p_max, native_format, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool DragScalar(string label, ImGuiDataType data_type, IntPtr p_data, float v_speed, IntPtr p_min, IntPtr p_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -6285,9 +11510,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragScalar(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, float v_speed, IntPtr p_min, IntPtr p_max, ReadOnlySpan<char> format)
-#else
-        public static bool DragScalar(string label, ImGuiDataType data_type, IntPtr p_data, float v_speed, IntPtr p_min, IntPtr p_max, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            void* native_p_data = (void*)p_data.ToPointer();
+            void* native_p_min = (void*)p_min.ToPointer();
+            void* native_p_max = (void*)p_max.ToPointer();
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            byte ret = ImGuiNative.igDragScalar(native_label, data_type, native_p_data, v_speed, native_p_min, native_p_max, native_format, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            if (format_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_format);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool DragScalar(string label, ImGuiDataType data_type, IntPtr p_data, float v_speed, IntPtr p_min, IntPtr p_max, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -6342,9 +11618,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragScalar(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, float v_speed, IntPtr p_min, IntPtr p_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool DragScalar(string label, ImGuiDataType data_type, IntPtr p_data, float v_speed, IntPtr p_min, IntPtr p_max, string format, ImGuiSliderFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            void* native_p_data = (void*)p_data.ToPointer();
+            void* native_p_min = (void*)p_min.ToPointer();
+            void* native_p_max = (void*)p_max.ToPointer();
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            byte ret = ImGuiNative.igDragScalar(native_label, data_type, native_p_data, v_speed, native_p_min, native_p_max, native_format, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            if (format_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_format);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool DragScalar(string label, ImGuiDataType data_type, IntPtr p_data, float v_speed, IntPtr p_min, IntPtr p_max, string format, ImGuiSliderFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -6398,9 +11724,40 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragScalarN(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, int components)
-#else
-        public static bool DragScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            void* native_p_data = (void*)p_data.ToPointer();
+            float v_speed = 1.0f;
+            void* p_min = null;
+            void* p_max = null;
+            byte* native_format = null;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            byte ret = ImGuiNative.igDragScalarN(native_label, data_type, native_p_data, components, v_speed, p_min, p_max, native_format, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool DragScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -6435,9 +11792,39 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragScalarN(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, int components, float v_speed)
-#else
-        public static bool DragScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, float v_speed)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            void* native_p_data = (void*)p_data.ToPointer();
+            void* p_min = null;
+            void* p_max = null;
+            byte* native_format = null;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            byte ret = ImGuiNative.igDragScalarN(native_label, data_type, native_p_data, components, v_speed, p_min, p_max, native_format, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool DragScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, float v_speed)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -6471,9 +11858,39 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragScalarN(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, int components, float v_speed, IntPtr p_min)
-#else
-        public static bool DragScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, float v_speed, IntPtr p_min)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            void* native_p_data = (void*)p_data.ToPointer();
+            void* native_p_min = (void*)p_min.ToPointer();
+            void* p_max = null;
+            byte* native_format = null;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            byte ret = ImGuiNative.igDragScalarN(native_label, data_type, native_p_data, components, v_speed, native_p_min, p_max, native_format, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool DragScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, float v_speed, IntPtr p_min)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -6507,9 +11924,39 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragScalarN(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, int components, float v_speed, IntPtr p_min, IntPtr p_max)
-#else
-        public static bool DragScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, float v_speed, IntPtr p_min, IntPtr p_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            void* native_p_data = (void*)p_data.ToPointer();
+            void* native_p_min = (void*)p_min.ToPointer();
+            void* native_p_max = (void*)p_max.ToPointer();
+            byte* native_format = null;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            byte ret = ImGuiNative.igDragScalarN(native_label, data_type, native_p_data, components, v_speed, native_p_min, native_p_max, native_format, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool DragScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, float v_speed, IntPtr p_min, IntPtr p_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -6543,9 +11990,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragScalarN(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, int components, float v_speed, IntPtr p_min, IntPtr p_max, ReadOnlySpan<char> format)
-#else
-        public static bool DragScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, float v_speed, IntPtr p_min, IntPtr p_max, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            void* native_p_data = (void*)p_data.ToPointer();
+            void* native_p_min = (void*)p_min.ToPointer();
+            void* native_p_max = (void*)p_max.ToPointer();
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            byte ret = ImGuiNative.igDragScalarN(native_label, data_type, native_p_data, components, v_speed, native_p_min, native_p_max, native_format, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            if (format_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_format);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool DragScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, float v_speed, IntPtr p_min, IntPtr p_max, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -6600,9 +12098,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool DragScalarN(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, int components, float v_speed, IntPtr p_min, IntPtr p_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool DragScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, float v_speed, IntPtr p_min, IntPtr p_max, string format, ImGuiSliderFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            void* native_p_data = (void*)p_data.ToPointer();
+            void* native_p_min = (void*)p_min.ToPointer();
+            void* native_p_max = (void*)p_max.ToPointer();
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            byte ret = ImGuiNative.igDragScalarN(native_label, data_type, native_p_data, components, v_speed, native_p_min, native_p_max, native_format, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            if (format_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_format);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool DragScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, float v_speed, IntPtr p_min, IntPtr p_max, string format, ImGuiSliderFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -6927,9 +12475,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static uint GetID(ReadOnlySpan<char> str_id)
-#else
-        public static uint GetID(string str_id)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            uint ret = ImGuiNative.igGetID_Str(native_str_id);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+            return ret;
+        }
 #endif
+        public static uint GetID(string str_id)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -7209,9 +12782,38 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ImageButton(ReadOnlySpan<char> str_id, IntPtr user_texture_id, Vector2 size)
-#else
-        public static bool ImageButton(string str_id, IntPtr user_texture_id, Vector2 size)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            Vector2 uv0 = new Vector2();
+            Vector2 uv1 = new Vector2(1, 1);
+            Vector4 bg_col = new Vector4();
+            Vector4 tint_col = new Vector4(1, 1, 1, 1);
+            byte ret = ImGuiNative.igImageButton(native_str_id, user_texture_id, size, uv0, uv1, bg_col, tint_col);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool ImageButton(string str_id, IntPtr user_texture_id, Vector2 size)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -7244,9 +12846,37 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ImageButton(ReadOnlySpan<char> str_id, IntPtr user_texture_id, Vector2 size, Vector2 uv0)
-#else
-        public static bool ImageButton(string str_id, IntPtr user_texture_id, Vector2 size, Vector2 uv0)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            Vector2 uv1 = new Vector2(1, 1);
+            Vector4 bg_col = new Vector4();
+            Vector4 tint_col = new Vector4(1, 1, 1, 1);
+            byte ret = ImGuiNative.igImageButton(native_str_id, user_texture_id, size, uv0, uv1, bg_col, tint_col);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool ImageButton(string str_id, IntPtr user_texture_id, Vector2 size, Vector2 uv0)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -7278,9 +12908,36 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ImageButton(ReadOnlySpan<char> str_id, IntPtr user_texture_id, Vector2 size, Vector2 uv0, Vector2 uv1)
-#else
-        public static bool ImageButton(string str_id, IntPtr user_texture_id, Vector2 size, Vector2 uv0, Vector2 uv1)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            Vector4 bg_col = new Vector4();
+            Vector4 tint_col = new Vector4(1, 1, 1, 1);
+            byte ret = ImGuiNative.igImageButton(native_str_id, user_texture_id, size, uv0, uv1, bg_col, tint_col);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool ImageButton(string str_id, IntPtr user_texture_id, Vector2 size, Vector2 uv0, Vector2 uv1)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -7311,9 +12968,35 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ImageButton(ReadOnlySpan<char> str_id, IntPtr user_texture_id, Vector2 size, Vector2 uv0, Vector2 uv1, Vector4 bg_col)
-#else
-        public static bool ImageButton(string str_id, IntPtr user_texture_id, Vector2 size, Vector2 uv0, Vector2 uv1, Vector4 bg_col)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            Vector4 tint_col = new Vector4(1, 1, 1, 1);
+            byte ret = ImGuiNative.igImageButton(native_str_id, user_texture_id, size, uv0, uv1, bg_col, tint_col);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool ImageButton(string str_id, IntPtr user_texture_id, Vector2 size, Vector2 uv0, Vector2 uv1, Vector4 bg_col)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -7343,9 +13026,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ImageButton(ReadOnlySpan<char> str_id, IntPtr user_texture_id, Vector2 size, Vector2 uv0, Vector2 uv1, Vector4 bg_col, Vector4 tint_col)
-#else
-        public static bool ImageButton(string str_id, IntPtr user_texture_id, Vector2 size, Vector2 uv0, Vector2 uv1, Vector4 bg_col, Vector4 tint_col)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            byte ret = ImGuiNative.igImageButton(native_str_id, user_texture_id, size, uv0, uv1, bg_col, tint_col);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool ImageButton(string str_id, IntPtr user_texture_id, Vector2 size, Vector2 uv0, Vector2 uv1, Vector4 bg_col, Vector4 tint_col)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -7383,9 +13091,58 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputDouble(ReadOnlySpan<char> label, ref double v)
-#else
-        public static bool InputDouble(string label, ref double v)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            double step = 0.0;
+            double step_fast = 0.0;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.6f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.6f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiInputTextFlags flags = (ImGuiInputTextFlags)0;
+            fixed (double* native_v = &v)
+            {
+                byte ret = ImGuiNative.igInputDouble(native_label, native_v, step, step_fast, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool InputDouble(string label, ref double v)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -7438,9 +13195,57 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputDouble(ReadOnlySpan<char> label, ref double v, double step)
-#else
-        public static bool InputDouble(string label, ref double v, double step)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            double step_fast = 0.0;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.6f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.6f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiInputTextFlags flags = (ImGuiInputTextFlags)0;
+            fixed (double* native_v = &v)
+            {
+                byte ret = ImGuiNative.igInputDouble(native_label, native_v, step, step_fast, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool InputDouble(string label, ref double v, double step)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -7492,9 +13297,56 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputDouble(ReadOnlySpan<char> label, ref double v, double step, double step_fast)
-#else
-        public static bool InputDouble(string label, ref double v, double step, double step_fast)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.6f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.6f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiInputTextFlags flags = (ImGuiInputTextFlags)0;
+            fixed (double* native_v = &v)
+            {
+                byte ret = ImGuiNative.igInputDouble(native_label, native_v, step, step_fast, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool InputDouble(string label, ref double v, double step, double step_fast)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -7545,9 +13397,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputDouble(ReadOnlySpan<char> label, ref double v, double step, double step_fast, ReadOnlySpan<char> format)
-#else
-        public static bool InputDouble(string label, ref double v, double step, double step_fast, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            ImGuiInputTextFlags flags = (ImGuiInputTextFlags)0;
+            fixed (double* native_v = &v)
+            {
+                byte ret = ImGuiNative.igInputDouble(native_label, native_v, step, step_fast, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool InputDouble(string label, ref double v, double step, double step_fast, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -7602,9 +13505,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputDouble(ReadOnlySpan<char> label, ref double v, double step, double step_fast, ReadOnlySpan<char> format, ImGuiInputTextFlags flags)
-#else
-        public static bool InputDouble(string label, ref double v, double step, double step_fast, string format, ImGuiInputTextFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            fixed (double* native_v = &v)
+            {
+                byte ret = ImGuiNative.igInputDouble(native_label, native_v, step, step_fast, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool InputDouble(string label, ref double v, double step, double step_fast, string format, ImGuiInputTextFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -7658,9 +13611,58 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputFloat(ReadOnlySpan<char> label, ref float v)
-#else
-        public static bool InputFloat(string label, ref float v)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            float step = 0.0f;
+            float step_fast = 0.0f;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.3f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiInputTextFlags flags = (ImGuiInputTextFlags)0;
+            fixed (float* native_v = &v)
+            {
+                byte ret = ImGuiNative.igInputFloat(native_label, native_v, step, step_fast, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool InputFloat(string label, ref float v)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -7713,9 +13715,57 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputFloat(ReadOnlySpan<char> label, ref float v, float step)
-#else
-        public static bool InputFloat(string label, ref float v, float step)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            float step_fast = 0.0f;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.3f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiInputTextFlags flags = (ImGuiInputTextFlags)0;
+            fixed (float* native_v = &v)
+            {
+                byte ret = ImGuiNative.igInputFloat(native_label, native_v, step, step_fast, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool InputFloat(string label, ref float v, float step)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -7767,9 +13817,56 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputFloat(ReadOnlySpan<char> label, ref float v, float step, float step_fast)
-#else
-        public static bool InputFloat(string label, ref float v, float step, float step_fast)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.3f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiInputTextFlags flags = (ImGuiInputTextFlags)0;
+            fixed (float* native_v = &v)
+            {
+                byte ret = ImGuiNative.igInputFloat(native_label, native_v, step, step_fast, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool InputFloat(string label, ref float v, float step, float step_fast)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -7820,9 +13917,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputFloat(ReadOnlySpan<char> label, ref float v, float step, float step_fast, ReadOnlySpan<char> format)
-#else
-        public static bool InputFloat(string label, ref float v, float step, float step_fast, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            ImGuiInputTextFlags flags = (ImGuiInputTextFlags)0;
+            fixed (float* native_v = &v)
+            {
+                byte ret = ImGuiNative.igInputFloat(native_label, native_v, step, step_fast, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool InputFloat(string label, ref float v, float step, float step_fast, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -7877,9 +14025,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputFloat(ReadOnlySpan<char> label, ref float v, float step, float step_fast, ReadOnlySpan<char> format, ImGuiInputTextFlags flags)
-#else
-        public static bool InputFloat(string label, ref float v, float step, float step_fast, string format, ImGuiInputTextFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            fixed (float* native_v = &v)
+            {
+                byte ret = ImGuiNative.igInputFloat(native_label, native_v, step, step_fast, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool InputFloat(string label, ref float v, float step, float step_fast, string format, ImGuiInputTextFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -7933,9 +14131,56 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputFloat2(ReadOnlySpan<char> label, ref Vector2 v)
-#else
-        public static bool InputFloat2(string label, ref Vector2 v)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.3f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiInputTextFlags flags = (ImGuiInputTextFlags)0;
+            fixed (Vector2* native_v = &v)
+            {
+                byte ret = ImGuiNative.igInputFloat2(native_label, native_v, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool InputFloat2(string label, ref Vector2 v)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -7986,9 +14231,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputFloat2(ReadOnlySpan<char> label, ref Vector2 v, ReadOnlySpan<char> format)
-#else
-        public static bool InputFloat2(string label, ref Vector2 v, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            ImGuiInputTextFlags flags = (ImGuiInputTextFlags)0;
+            fixed (Vector2* native_v = &v)
+            {
+                byte ret = ImGuiNative.igInputFloat2(native_label, native_v, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool InputFloat2(string label, ref Vector2 v, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -8043,9 +14339,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputFloat2(ReadOnlySpan<char> label, ref Vector2 v, ReadOnlySpan<char> format, ImGuiInputTextFlags flags)
-#else
-        public static bool InputFloat2(string label, ref Vector2 v, string format, ImGuiInputTextFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            fixed (Vector2* native_v = &v)
+            {
+                byte ret = ImGuiNative.igInputFloat2(native_label, native_v, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool InputFloat2(string label, ref Vector2 v, string format, ImGuiInputTextFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -8099,9 +14445,56 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputFloat3(ReadOnlySpan<char> label, ref Vector3 v)
-#else
-        public static bool InputFloat3(string label, ref Vector3 v)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.3f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiInputTextFlags flags = (ImGuiInputTextFlags)0;
+            fixed (Vector3* native_v = &v)
+            {
+                byte ret = ImGuiNative.igInputFloat3(native_label, native_v, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool InputFloat3(string label, ref Vector3 v)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -8152,9 +14545,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputFloat3(ReadOnlySpan<char> label, ref Vector3 v, ReadOnlySpan<char> format)
-#else
-        public static bool InputFloat3(string label, ref Vector3 v, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            ImGuiInputTextFlags flags = (ImGuiInputTextFlags)0;
+            fixed (Vector3* native_v = &v)
+            {
+                byte ret = ImGuiNative.igInputFloat3(native_label, native_v, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool InputFloat3(string label, ref Vector3 v, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -8209,9 +14653,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputFloat3(ReadOnlySpan<char> label, ref Vector3 v, ReadOnlySpan<char> format, ImGuiInputTextFlags flags)
-#else
-        public static bool InputFloat3(string label, ref Vector3 v, string format, ImGuiInputTextFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            fixed (Vector3* native_v = &v)
+            {
+                byte ret = ImGuiNative.igInputFloat3(native_label, native_v, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool InputFloat3(string label, ref Vector3 v, string format, ImGuiInputTextFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -8265,9 +14759,56 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputFloat4(ReadOnlySpan<char> label, ref Vector4 v)
-#else
-        public static bool InputFloat4(string label, ref Vector4 v)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.3f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiInputTextFlags flags = (ImGuiInputTextFlags)0;
+            fixed (Vector4* native_v = &v)
+            {
+                byte ret = ImGuiNative.igInputFloat4(native_label, native_v, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool InputFloat4(string label, ref Vector4 v)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -8318,9 +14859,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputFloat4(ReadOnlySpan<char> label, ref Vector4 v, ReadOnlySpan<char> format)
-#else
-        public static bool InputFloat4(string label, ref Vector4 v, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            ImGuiInputTextFlags flags = (ImGuiInputTextFlags)0;
+            fixed (Vector4* native_v = &v)
+            {
+                byte ret = ImGuiNative.igInputFloat4(native_label, native_v, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool InputFloat4(string label, ref Vector4 v, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -8375,9 +14967,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputFloat4(ReadOnlySpan<char> label, ref Vector4 v, ReadOnlySpan<char> format, ImGuiInputTextFlags flags)
-#else
-        public static bool InputFloat4(string label, ref Vector4 v, string format, ImGuiInputTextFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            fixed (Vector4* native_v = &v)
+            {
+                byte ret = ImGuiNative.igInputFloat4(native_label, native_v, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool InputFloat4(string label, ref Vector4 v, string format, ImGuiInputTextFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -8431,9 +15073,40 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputInt(ReadOnlySpan<char> label, ref int v)
-#else
-        public static bool InputInt(string label, ref int v)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            int step = 1;
+            int step_fast = 100;
+            ImGuiInputTextFlags flags = (ImGuiInputTextFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igInputInt(native_label, native_v, step, step_fast, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool InputInt(string label, ref int v)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -8468,9 +15141,39 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputInt(ReadOnlySpan<char> label, ref int v, int step)
-#else
-        public static bool InputInt(string label, ref int v, int step)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            int step_fast = 100;
+            ImGuiInputTextFlags flags = (ImGuiInputTextFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igInputInt(native_label, native_v, step, step_fast, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool InputInt(string label, ref int v, int step)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -8504,9 +15207,38 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputInt(ReadOnlySpan<char> label, ref int v, int step, int step_fast)
-#else
-        public static bool InputInt(string label, ref int v, int step, int step_fast)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            ImGuiInputTextFlags flags = (ImGuiInputTextFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igInputInt(native_label, native_v, step, step_fast, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool InputInt(string label, ref int v, int step, int step_fast)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -8539,9 +15271,37 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputInt(ReadOnlySpan<char> label, ref int v, int step, int step_fast, ImGuiInputTextFlags flags)
-#else
-        public static bool InputInt(string label, ref int v, int step, int step_fast, ImGuiInputTextFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igInputInt(native_label, native_v, step, step_fast, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool InputInt(string label, ref int v, int step, int step_fast, ImGuiInputTextFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -8573,9 +15333,38 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputInt2(ReadOnlySpan<char> label, ref int v)
-#else
-        public static bool InputInt2(string label, ref int v)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            ImGuiInputTextFlags flags = (ImGuiInputTextFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igInputInt2(native_label, native_v, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool InputInt2(string label, ref int v)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -8608,9 +15397,37 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputInt2(ReadOnlySpan<char> label, ref int v, ImGuiInputTextFlags flags)
-#else
-        public static bool InputInt2(string label, ref int v, ImGuiInputTextFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igInputInt2(native_label, native_v, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool InputInt2(string label, ref int v, ImGuiInputTextFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -8642,9 +15459,38 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputInt3(ReadOnlySpan<char> label, ref int v)
-#else
-        public static bool InputInt3(string label, ref int v)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            ImGuiInputTextFlags flags = (ImGuiInputTextFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igInputInt3(native_label, native_v, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool InputInt3(string label, ref int v)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -8677,9 +15523,37 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputInt3(ReadOnlySpan<char> label, ref int v, ImGuiInputTextFlags flags)
-#else
-        public static bool InputInt3(string label, ref int v, ImGuiInputTextFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igInputInt3(native_label, native_v, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool InputInt3(string label, ref int v, ImGuiInputTextFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -8711,9 +15585,38 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputInt4(ReadOnlySpan<char> label, ref int v)
-#else
-        public static bool InputInt4(string label, ref int v)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            ImGuiInputTextFlags flags = (ImGuiInputTextFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igInputInt4(native_label, native_v, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool InputInt4(string label, ref int v)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -8746,9 +15649,37 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputInt4(ReadOnlySpan<char> label, ref int v, ImGuiInputTextFlags flags)
-#else
-        public static bool InputInt4(string label, ref int v, ImGuiInputTextFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igInputInt4(native_label, native_v, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool InputInt4(string label, ref int v, ImGuiInputTextFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -8780,9 +15711,39 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputScalar(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data)
-#else
-        public static bool InputScalar(string label, ImGuiDataType data_type, IntPtr p_data)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            void* native_p_data = (void*)p_data.ToPointer();
+            void* p_step = null;
+            void* p_step_fast = null;
+            byte* native_format = null;
+            ImGuiInputTextFlags flags = (ImGuiInputTextFlags)0;
+            byte ret = ImGuiNative.igInputScalar(native_label, data_type, native_p_data, p_step, p_step_fast, native_format, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool InputScalar(string label, ImGuiDataType data_type, IntPtr p_data)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -8816,9 +15777,39 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputScalar(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_step)
-#else
-        public static bool InputScalar(string label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_step)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            void* native_p_data = (void*)p_data.ToPointer();
+            void* native_p_step = (void*)p_step.ToPointer();
+            void* p_step_fast = null;
+            byte* native_format = null;
+            ImGuiInputTextFlags flags = (ImGuiInputTextFlags)0;
+            byte ret = ImGuiNative.igInputScalar(native_label, data_type, native_p_data, native_p_step, p_step_fast, native_format, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool InputScalar(string label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_step)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -8852,9 +15843,39 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputScalar(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_step, IntPtr p_step_fast)
-#else
-        public static bool InputScalar(string label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_step, IntPtr p_step_fast)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            void* native_p_data = (void*)p_data.ToPointer();
+            void* native_p_step = (void*)p_step.ToPointer();
+            void* native_p_step_fast = (void*)p_step_fast.ToPointer();
+            byte* native_format = null;
+            ImGuiInputTextFlags flags = (ImGuiInputTextFlags)0;
+            byte ret = ImGuiNative.igInputScalar(native_label, data_type, native_p_data, native_p_step, native_p_step_fast, native_format, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool InputScalar(string label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_step, IntPtr p_step_fast)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -8888,9 +15909,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputScalar(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_step, IntPtr p_step_fast, ReadOnlySpan<char> format)
-#else
-        public static bool InputScalar(string label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_step, IntPtr p_step_fast, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            void* native_p_data = (void*)p_data.ToPointer();
+            void* native_p_step = (void*)p_step.ToPointer();
+            void* native_p_step_fast = (void*)p_step_fast.ToPointer();
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            ImGuiInputTextFlags flags = (ImGuiInputTextFlags)0;
+            byte ret = ImGuiNative.igInputScalar(native_label, data_type, native_p_data, native_p_step, native_p_step_fast, native_format, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            if (format_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_format);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool InputScalar(string label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_step, IntPtr p_step_fast, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -8945,9 +16017,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputScalar(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_step, IntPtr p_step_fast, ReadOnlySpan<char> format, ImGuiInputTextFlags flags)
-#else
-        public static bool InputScalar(string label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_step, IntPtr p_step_fast, string format, ImGuiInputTextFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            void* native_p_data = (void*)p_data.ToPointer();
+            void* native_p_step = (void*)p_step.ToPointer();
+            void* native_p_step_fast = (void*)p_step_fast.ToPointer();
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            byte ret = ImGuiNative.igInputScalar(native_label, data_type, native_p_data, native_p_step, native_p_step_fast, native_format, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            if (format_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_format);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool InputScalar(string label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_step, IntPtr p_step_fast, string format, ImGuiInputTextFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -9001,9 +16123,39 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputScalarN(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, int components)
-#else
-        public static bool InputScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            void* native_p_data = (void*)p_data.ToPointer();
+            void* p_step = null;
+            void* p_step_fast = null;
+            byte* native_format = null;
+            ImGuiInputTextFlags flags = (ImGuiInputTextFlags)0;
+            byte ret = ImGuiNative.igInputScalarN(native_label, data_type, native_p_data, components, p_step, p_step_fast, native_format, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool InputScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -9037,9 +16189,39 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputScalarN(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_step)
-#else
-        public static bool InputScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_step)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            void* native_p_data = (void*)p_data.ToPointer();
+            void* native_p_step = (void*)p_step.ToPointer();
+            void* p_step_fast = null;
+            byte* native_format = null;
+            ImGuiInputTextFlags flags = (ImGuiInputTextFlags)0;
+            byte ret = ImGuiNative.igInputScalarN(native_label, data_type, native_p_data, components, native_p_step, p_step_fast, native_format, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool InputScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_step)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -9073,9 +16255,39 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputScalarN(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_step, IntPtr p_step_fast)
-#else
-        public static bool InputScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_step, IntPtr p_step_fast)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            void* native_p_data = (void*)p_data.ToPointer();
+            void* native_p_step = (void*)p_step.ToPointer();
+            void* native_p_step_fast = (void*)p_step_fast.ToPointer();
+            byte* native_format = null;
+            ImGuiInputTextFlags flags = (ImGuiInputTextFlags)0;
+            byte ret = ImGuiNative.igInputScalarN(native_label, data_type, native_p_data, components, native_p_step, native_p_step_fast, native_format, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool InputScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_step, IntPtr p_step_fast)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -9109,9 +16321,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputScalarN(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_step, IntPtr p_step_fast, ReadOnlySpan<char> format)
-#else
-        public static bool InputScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_step, IntPtr p_step_fast, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            void* native_p_data = (void*)p_data.ToPointer();
+            void* native_p_step = (void*)p_step.ToPointer();
+            void* native_p_step_fast = (void*)p_step_fast.ToPointer();
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            ImGuiInputTextFlags flags = (ImGuiInputTextFlags)0;
+            byte ret = ImGuiNative.igInputScalarN(native_label, data_type, native_p_data, components, native_p_step, native_p_step_fast, native_format, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            if (format_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_format);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool InputScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_step, IntPtr p_step_fast, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -9166,9 +16429,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InputScalarN(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_step, IntPtr p_step_fast, ReadOnlySpan<char> format, ImGuiInputTextFlags flags)
-#else
-        public static bool InputScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_step, IntPtr p_step_fast, string format, ImGuiInputTextFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            void* native_p_data = (void*)p_data.ToPointer();
+            void* native_p_step = (void*)p_step.ToPointer();
+            void* native_p_step_fast = (void*)p_step_fast.ToPointer();
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            byte ret = ImGuiNative.igInputScalarN(native_label, data_type, native_p_data, components, native_p_step, native_p_step_fast, native_format, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            if (format_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_format);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool InputScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_step, IntPtr p_step_fast, string format, ImGuiInputTextFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -9222,9 +16535,35 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InvisibleButton(ReadOnlySpan<char> str_id, Vector2 size)
-#else
-        public static bool InvisibleButton(string str_id, Vector2 size)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            ImGuiButtonFlags flags = (ImGuiButtonFlags)0;
+            byte ret = ImGuiNative.igInvisibleButton(native_str_id, size, flags);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool InvisibleButton(string str_id, Vector2 size)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -9254,9 +16593,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool InvisibleButton(ReadOnlySpan<char> str_id, Vector2 size, ImGuiButtonFlags flags)
-#else
-        public static bool InvisibleButton(string str_id, Vector2 size, ImGuiButtonFlags flags)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            byte ret = ImGuiNative.igInvisibleButton(native_str_id, size, flags);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool InvisibleButton(string str_id, Vector2 size, ImGuiButtonFlags flags)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -9453,9 +16817,35 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool IsPopupOpen(ReadOnlySpan<char> str_id)
-#else
-        public static bool IsPopupOpen(string str_id)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            ImGuiPopupFlags flags = (ImGuiPopupFlags)0;
+            byte ret = ImGuiNative.igIsPopupOpen_Str(native_str_id, flags);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool IsPopupOpen(string str_id)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -9485,9 +16875,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool IsPopupOpen(ReadOnlySpan<char> str_id, ImGuiPopupFlags flags)
-#else
-        public static bool IsPopupOpen(string str_id, ImGuiPopupFlags flags)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            byte ret = ImGuiNative.igIsPopupOpen_Str(native_str_id, flags);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool IsPopupOpen(string str_id, ImGuiPopupFlags flags)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -9563,9 +16978,55 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void LabelText(ReadOnlySpan<char> label, ReadOnlySpan<char> fmt)
-#else
-        public static void LabelText(string label, string fmt)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_fmt;
+            int fmt_byteCount = 0;
+            if (fmt != null)
+            {
+                fmt_byteCount = Encoding.UTF8.GetByteCount(fmt);
+                if (fmt_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_fmt = Util.Allocate(fmt_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_fmt_stackBytes = stackalloc byte[fmt_byteCount + 1];
+                    native_fmt = native_fmt_stackBytes;
+                }
+                int native_fmt_offset = Util.GetUtf8(fmt, native_fmt, fmt_byteCount);
+                native_fmt[native_fmt_offset] = 0;
+            }
+            else { native_fmt = null; }
+            ImGuiNative.igLabelText(native_label, native_fmt);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            if (fmt_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_fmt);
+            }
+        }
 #endif
+        public static void LabelText(string label, string fmt)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -9615,9 +17076,65 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ListBox(ReadOnlySpan<char> label, ref int current_item, string[] items, int items_count)
-#else
-        public static bool ListBox(string label, ref int current_item, string[] items, int items_count)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            int* items_byteCounts = stackalloc int[items.Length];
+            int items_byteCount = 0;
+            for (int i = 0; i < items.Length; i++)
+            {
+                string s = items[i];
+                items_byteCounts[i] = Encoding.UTF8.GetByteCount(s);
+                items_byteCount += items_byteCounts[i] + 1;
+            }
+            byte* native_items_data = stackalloc byte[items_byteCount];
+            int offset = 0;
+            for (int i = 0; i < items.Length; i++)
+            {
+                string s = items[i];
+                fixed (char* sPtr = s)
+                {
+                    offset += Encoding.UTF8.GetBytes(sPtr, s.Length, native_items_data + offset, items_byteCounts[i]);
+                    native_items_data[offset] = 0;
+                    offset += 1;
+                }
+            }
+            byte** native_items = stackalloc byte*[items.Length];
+            offset = 0;
+            for (int i = 0; i < items.Length; i++)
+            {
+                native_items[i] = &native_items_data[offset];
+                offset += items_byteCounts[i] + 1;
+            }
+            int height_in_items = -1;
+            fixed (int* native_current_item = &current_item)
+            {
+                byte ret = ImGuiNative.igListBox_Str_arr(native_label, native_current_item, native_items, items_count, height_in_items);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool ListBox(string label, ref int current_item, string[] items, int items_count)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -9677,9 +17194,64 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ListBox(ReadOnlySpan<char> label, ref int current_item, string[] items, int items_count, int height_in_items)
-#else
-        public static bool ListBox(string label, ref int current_item, string[] items, int items_count, int height_in_items)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            int* items_byteCounts = stackalloc int[items.Length];
+            int items_byteCount = 0;
+            for (int i = 0; i < items.Length; i++)
+            {
+                string s = items[i];
+                items_byteCounts[i] = Encoding.UTF8.GetByteCount(s);
+                items_byteCount += items_byteCounts[i] + 1;
+            }
+            byte* native_items_data = stackalloc byte[items_byteCount];
+            int offset = 0;
+            for (int i = 0; i < items.Length; i++)
+            {
+                string s = items[i];
+                fixed (char* sPtr = s)
+                {
+                    offset += Encoding.UTF8.GetBytes(sPtr, s.Length, native_items_data + offset, items_byteCounts[i]);
+                    native_items_data[offset] = 0;
+                    offset += 1;
+                }
+            }
+            byte** native_items = stackalloc byte*[items.Length];
+            offset = 0;
+            for (int i = 0; i < items.Length; i++)
+            {
+                native_items[i] = &native_items_data[offset];
+                offset += items_byteCounts[i] + 1;
+            }
+            fixed (int* native_current_item = &current_item)
+            {
+                byte ret = ImGuiNative.igListBox_Str_arr(native_label, native_current_item, native_items, items_count, height_in_items);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool ListBox(string label, ref int current_item, string[] items, int items_count, int height_in_items)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -9738,9 +17310,33 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void LoadIniSettingsFromDisk(ReadOnlySpan<char> ini_filename)
-#else
-        public static void LoadIniSettingsFromDisk(string ini_filename)
+        {
+            byte* native_ini_filename;
+            int ini_filename_byteCount = 0;
+            if (ini_filename != null)
+            {
+                ini_filename_byteCount = Encoding.UTF8.GetByteCount(ini_filename);
+                if (ini_filename_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_ini_filename = Util.Allocate(ini_filename_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_ini_filename_stackBytes = stackalloc byte[ini_filename_byteCount + 1];
+                    native_ini_filename = native_ini_filename_stackBytes;
+                }
+                int native_ini_filename_offset = Util.GetUtf8(ini_filename, native_ini_filename, ini_filename_byteCount);
+                native_ini_filename[native_ini_filename_offset] = 0;
+            }
+            else { native_ini_filename = null; }
+            ImGuiNative.igLoadIniSettingsFromDisk(native_ini_filename);
+            if (ini_filename_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_ini_filename);
+            }
+        }
 #endif
+        public static void LoadIniSettingsFromDisk(string ini_filename)
         {
             byte* native_ini_filename;
             int ini_filename_byteCount = 0;
@@ -9768,9 +17364,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void LoadIniSettingsFromMemory(ReadOnlySpan<char> ini_data)
-#else
-        public static void LoadIniSettingsFromMemory(string ini_data)
+        {
+            byte* native_ini_data;
+            int ini_data_byteCount = 0;
+            if (ini_data != null)
+            {
+                ini_data_byteCount = Encoding.UTF8.GetByteCount(ini_data);
+                if (ini_data_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_ini_data = Util.Allocate(ini_data_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_ini_data_stackBytes = stackalloc byte[ini_data_byteCount + 1];
+                    native_ini_data = native_ini_data_stackBytes;
+                }
+                int native_ini_data_offset = Util.GetUtf8(ini_data, native_ini_data, ini_data_byteCount);
+                native_ini_data[native_ini_data_offset] = 0;
+            }
+            else { native_ini_data = null; }
+            uint ini_size = 0;
+            ImGuiNative.igLoadIniSettingsFromMemory(native_ini_data, ini_size);
+            if (ini_data_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_ini_data);
+            }
+        }
 #endif
+        public static void LoadIniSettingsFromMemory(string ini_data)
         {
             byte* native_ini_data;
             int ini_data_byteCount = 0;
@@ -9799,9 +17420,33 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void LoadIniSettingsFromMemory(ReadOnlySpan<char> ini_data, uint ini_size)
-#else
-        public static void LoadIniSettingsFromMemory(string ini_data, uint ini_size)
+        {
+            byte* native_ini_data;
+            int ini_data_byteCount = 0;
+            if (ini_data != null)
+            {
+                ini_data_byteCount = Encoding.UTF8.GetByteCount(ini_data);
+                if (ini_data_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_ini_data = Util.Allocate(ini_data_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_ini_data_stackBytes = stackalloc byte[ini_data_byteCount + 1];
+                    native_ini_data = native_ini_data_stackBytes;
+                }
+                int native_ini_data_offset = Util.GetUtf8(ini_data, native_ini_data, ini_data_byteCount);
+                native_ini_data[native_ini_data_offset] = 0;
+            }
+            else { native_ini_data = null; }
+            ImGuiNative.igLoadIniSettingsFromMemory(native_ini_data, ini_size);
+            if (ini_data_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_ini_data);
+            }
+        }
 #endif
+        public static void LoadIniSettingsFromMemory(string ini_data, uint ini_size)
         {
             byte* native_ini_data;
             int ini_data_byteCount = 0;
@@ -9837,9 +17482,33 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void LogText(ReadOnlySpan<char> fmt)
-#else
-        public static void LogText(string fmt)
+        {
+            byte* native_fmt;
+            int fmt_byteCount = 0;
+            if (fmt != null)
+            {
+                fmt_byteCount = Encoding.UTF8.GetByteCount(fmt);
+                if (fmt_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_fmt = Util.Allocate(fmt_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_fmt_stackBytes = stackalloc byte[fmt_byteCount + 1];
+                    native_fmt = native_fmt_stackBytes;
+                }
+                int native_fmt_offset = Util.GetUtf8(fmt, native_fmt, fmt_byteCount);
+                native_fmt[native_fmt_offset] = 0;
+            }
+            else { native_fmt = null; }
+            ImGuiNative.igLogText(native_fmt);
+            if (fmt_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_fmt);
+            }
+        }
 #endif
+        public static void LogText(string fmt)
         {
             byte* native_fmt;
             int fmt_byteCount = 0;
@@ -9887,9 +17556,33 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void LogToFile(int auto_open_depth, ReadOnlySpan<char> filename)
-#else
-        public static void LogToFile(int auto_open_depth, string filename)
+        {
+            byte* native_filename;
+            int filename_byteCount = 0;
+            if (filename != null)
+            {
+                filename_byteCount = Encoding.UTF8.GetByteCount(filename);
+                if (filename_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_filename = Util.Allocate(filename_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_filename_stackBytes = stackalloc byte[filename_byteCount + 1];
+                    native_filename = native_filename_stackBytes;
+                }
+                int native_filename_offset = Util.GetUtf8(filename, native_filename, filename_byteCount);
+                native_filename[native_filename_offset] = 0;
+            }
+            else { native_filename = null; }
+            ImGuiNative.igLogToFile(auto_open_depth, native_filename);
+            if (filename_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_filename);
+            }
+        }
 #endif
+        public static void LogToFile(int auto_open_depth, string filename)
         {
             byte* native_filename;
             int filename_byteCount = 0;
@@ -9936,9 +17629,37 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool MenuItem(ReadOnlySpan<char> label)
-#else
-        public static bool MenuItem(string label)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_shortcut = null;
+            byte selected = 0;
+            byte enabled = 1;
+            byte ret = ImGuiNative.igMenuItem_Bool(native_label, native_shortcut, selected, enabled);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool MenuItem(string label)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -9970,9 +17691,58 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool MenuItem(ReadOnlySpan<char> label, ReadOnlySpan<char> shortcut)
-#else
-        public static bool MenuItem(string label, string shortcut)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_shortcut;
+            int shortcut_byteCount = 0;
+            if (shortcut != null)
+            {
+                shortcut_byteCount = Encoding.UTF8.GetByteCount(shortcut);
+                if (shortcut_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_shortcut = Util.Allocate(shortcut_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_shortcut_stackBytes = stackalloc byte[shortcut_byteCount + 1];
+                    native_shortcut = native_shortcut_stackBytes;
+                }
+                int native_shortcut_offset = Util.GetUtf8(shortcut, native_shortcut, shortcut_byteCount);
+                native_shortcut[native_shortcut_offset] = 0;
+            }
+            else { native_shortcut = null; }
+            byte selected = 0;
+            byte enabled = 1;
+            byte ret = ImGuiNative.igMenuItem_Bool(native_label, native_shortcut, selected, enabled);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            if (shortcut_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_shortcut);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool MenuItem(string label, string shortcut)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -10025,9 +17795,58 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool MenuItem(ReadOnlySpan<char> label, ReadOnlySpan<char> shortcut, bool selected)
-#else
-        public static bool MenuItem(string label, string shortcut, bool selected)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_shortcut;
+            int shortcut_byteCount = 0;
+            if (shortcut != null)
+            {
+                shortcut_byteCount = Encoding.UTF8.GetByteCount(shortcut);
+                if (shortcut_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_shortcut = Util.Allocate(shortcut_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_shortcut_stackBytes = stackalloc byte[shortcut_byteCount + 1];
+                    native_shortcut = native_shortcut_stackBytes;
+                }
+                int native_shortcut_offset = Util.GetUtf8(shortcut, native_shortcut, shortcut_byteCount);
+                native_shortcut[native_shortcut_offset] = 0;
+            }
+            else { native_shortcut = null; }
+            byte native_selected = selected ? (byte)1 : (byte)0;
+            byte enabled = 1;
+            byte ret = ImGuiNative.igMenuItem_Bool(native_label, native_shortcut, native_selected, enabled);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            if (shortcut_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_shortcut);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool MenuItem(string label, string shortcut, bool selected)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -10080,9 +17899,58 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool MenuItem(ReadOnlySpan<char> label, ReadOnlySpan<char> shortcut, bool selected, bool enabled)
-#else
-        public static bool MenuItem(string label, string shortcut, bool selected, bool enabled)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_shortcut;
+            int shortcut_byteCount = 0;
+            if (shortcut != null)
+            {
+                shortcut_byteCount = Encoding.UTF8.GetByteCount(shortcut);
+                if (shortcut_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_shortcut = Util.Allocate(shortcut_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_shortcut_stackBytes = stackalloc byte[shortcut_byteCount + 1];
+                    native_shortcut = native_shortcut_stackBytes;
+                }
+                int native_shortcut_offset = Util.GetUtf8(shortcut, native_shortcut, shortcut_byteCount);
+                native_shortcut[native_shortcut_offset] = 0;
+            }
+            else { native_shortcut = null; }
+            byte native_selected = selected ? (byte)1 : (byte)0;
+            byte native_enabled = enabled ? (byte)1 : (byte)0;
+            byte ret = ImGuiNative.igMenuItem_Bool(native_label, native_shortcut, native_selected, native_enabled);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            if (shortcut_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_shortcut);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool MenuItem(string label, string shortcut, bool selected, bool enabled)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -10135,9 +18003,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool MenuItem(ReadOnlySpan<char> label, ReadOnlySpan<char> shortcut, ref bool p_selected)
-#else
-        public static bool MenuItem(string label, string shortcut, ref bool p_selected)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_shortcut;
+            int shortcut_byteCount = 0;
+            if (shortcut != null)
+            {
+                shortcut_byteCount = Encoding.UTF8.GetByteCount(shortcut);
+                if (shortcut_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_shortcut = Util.Allocate(shortcut_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_shortcut_stackBytes = stackalloc byte[shortcut_byteCount + 1];
+                    native_shortcut = native_shortcut_stackBytes;
+                }
+                int native_shortcut_offset = Util.GetUtf8(shortcut, native_shortcut, shortcut_byteCount);
+                native_shortcut[native_shortcut_offset] = 0;
+            }
+            else { native_shortcut = null; }
+            byte native_p_selected_val = p_selected ? (byte)1 : (byte)0;
+            byte* native_p_selected = &native_p_selected_val;
+            byte enabled = 1;
+            byte ret = ImGuiNative.igMenuItem_BoolPtr(native_label, native_shortcut, native_p_selected, enabled);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            if (shortcut_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_shortcut);
+            }
+            p_selected = native_p_selected_val != 0;
+            return ret != 0;
+        }
 #endif
+        public static bool MenuItem(string label, string shortcut, ref bool p_selected)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -10192,9 +18111,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool MenuItem(ReadOnlySpan<char> label, ReadOnlySpan<char> shortcut, ref bool p_selected, bool enabled)
-#else
-        public static bool MenuItem(string label, string shortcut, ref bool p_selected, bool enabled)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_shortcut;
+            int shortcut_byteCount = 0;
+            if (shortcut != null)
+            {
+                shortcut_byteCount = Encoding.UTF8.GetByteCount(shortcut);
+                if (shortcut_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_shortcut = Util.Allocate(shortcut_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_shortcut_stackBytes = stackalloc byte[shortcut_byteCount + 1];
+                    native_shortcut = native_shortcut_stackBytes;
+                }
+                int native_shortcut_offset = Util.GetUtf8(shortcut, native_shortcut, shortcut_byteCount);
+                native_shortcut[native_shortcut_offset] = 0;
+            }
+            else { native_shortcut = null; }
+            byte native_p_selected_val = p_selected ? (byte)1 : (byte)0;
+            byte* native_p_selected = &native_p_selected_val;
+            byte native_enabled = enabled ? (byte)1 : (byte)0;
+            byte ret = ImGuiNative.igMenuItem_BoolPtr(native_label, native_shortcut, native_p_selected, native_enabled);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            if (shortcut_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_shortcut);
+            }
+            p_selected = native_p_selected_val != 0;
+            return ret != 0;
+        }
 #endif
+        public static bool MenuItem(string label, string shortcut, ref bool p_selected, bool enabled)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -10261,9 +18231,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void OpenPopup(ReadOnlySpan<char> str_id)
-#else
-        public static void OpenPopup(string str_id)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            ImGuiPopupFlags popup_flags = (ImGuiPopupFlags)0;
+            ImGuiNative.igOpenPopup_Str(native_str_id, popup_flags);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+        }
 #endif
+        public static void OpenPopup(string str_id)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -10292,9 +18287,33 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void OpenPopup(ReadOnlySpan<char> str_id, ImGuiPopupFlags popup_flags)
-#else
-        public static void OpenPopup(string str_id, ImGuiPopupFlags popup_flags)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            ImGuiNative.igOpenPopup_Str(native_str_id, popup_flags);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+        }
 #endif
+        public static void OpenPopup(string str_id, ImGuiPopupFlags popup_flags)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -10337,9 +18356,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void OpenPopupOnItemClick(ReadOnlySpan<char> str_id)
-#else
-        public static void OpenPopupOnItemClick(string str_id)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            ImGuiPopupFlags popup_flags = (ImGuiPopupFlags)1;
+            ImGuiNative.igOpenPopupOnItemClick(native_str_id, popup_flags);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+        }
 #endif
+        public static void OpenPopupOnItemClick(string str_id)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -10368,9 +18412,33 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void OpenPopupOnItemClick(ReadOnlySpan<char> str_id, ImGuiPopupFlags popup_flags)
-#else
-        public static void OpenPopupOnItemClick(string str_id, ImGuiPopupFlags popup_flags)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            ImGuiNative.igOpenPopupOnItemClick(native_str_id, popup_flags);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+        }
 #endif
+        public static void OpenPopupOnItemClick(string str_id, ImGuiPopupFlags popup_flags)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -10398,9 +18466,42 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void PlotHistogram(ReadOnlySpan<char> label, ref float values, int values_count)
-#else
-        public static void PlotHistogram(string label, ref float values, int values_count)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            int values_offset = 0;
+            byte* native_overlay_text = null;
+            float scale_min = float.MaxValue;
+            float scale_max = float.MaxValue;
+            Vector2 graph_size = new Vector2();
+            int stride = sizeof(float);
+            fixed (float* native_values = &values)
+            {
+                ImGuiNative.igPlotHistogram_FloatPtr(native_label, native_values, values_count, values_offset, native_overlay_text, scale_min, scale_max, graph_size, stride);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+            }
+        }
 #endif
+        public static void PlotHistogram(string label, ref float values, int values_count)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -10437,9 +18538,41 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void PlotHistogram(ReadOnlySpan<char> label, ref float values, int values_count, int values_offset)
-#else
-        public static void PlotHistogram(string label, ref float values, int values_count, int values_offset)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_overlay_text = null;
+            float scale_min = float.MaxValue;
+            float scale_max = float.MaxValue;
+            Vector2 graph_size = new Vector2();
+            int stride = sizeof(float);
+            fixed (float* native_values = &values)
+            {
+                ImGuiNative.igPlotHistogram_FloatPtr(native_label, native_values, values_count, values_offset, native_overlay_text, scale_min, scale_max, graph_size, stride);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+            }
+        }
 #endif
+        public static void PlotHistogram(string label, ref float values, int values_count, int values_offset)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -10475,9 +18608,62 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void PlotHistogram(ReadOnlySpan<char> label, ref float values, int values_count, int values_offset, ReadOnlySpan<char> overlay_text)
-#else
-        public static void PlotHistogram(string label, ref float values, int values_count, int values_offset, string overlay_text)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_overlay_text;
+            int overlay_text_byteCount = 0;
+            if (overlay_text != null)
+            {
+                overlay_text_byteCount = Encoding.UTF8.GetByteCount(overlay_text);
+                if (overlay_text_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_overlay_text = Util.Allocate(overlay_text_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_overlay_text_stackBytes = stackalloc byte[overlay_text_byteCount + 1];
+                    native_overlay_text = native_overlay_text_stackBytes;
+                }
+                int native_overlay_text_offset = Util.GetUtf8(overlay_text, native_overlay_text, overlay_text_byteCount);
+                native_overlay_text[native_overlay_text_offset] = 0;
+            }
+            else { native_overlay_text = null; }
+            float scale_min = float.MaxValue;
+            float scale_max = float.MaxValue;
+            Vector2 graph_size = new Vector2();
+            int stride = sizeof(float);
+            fixed (float* native_values = &values)
+            {
+                ImGuiNative.igPlotHistogram_FloatPtr(native_label, native_values, values_count, values_offset, native_overlay_text, scale_min, scale_max, graph_size, stride);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (overlay_text_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_overlay_text);
+                }
+            }
+        }
 #endif
+        public static void PlotHistogram(string label, ref float values, int values_count, int values_offset, string overlay_text)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -10534,9 +18720,61 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void PlotHistogram(ReadOnlySpan<char> label, ref float values, int values_count, int values_offset, ReadOnlySpan<char> overlay_text, float scale_min)
-#else
-        public static void PlotHistogram(string label, ref float values, int values_count, int values_offset, string overlay_text, float scale_min)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_overlay_text;
+            int overlay_text_byteCount = 0;
+            if (overlay_text != null)
+            {
+                overlay_text_byteCount = Encoding.UTF8.GetByteCount(overlay_text);
+                if (overlay_text_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_overlay_text = Util.Allocate(overlay_text_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_overlay_text_stackBytes = stackalloc byte[overlay_text_byteCount + 1];
+                    native_overlay_text = native_overlay_text_stackBytes;
+                }
+                int native_overlay_text_offset = Util.GetUtf8(overlay_text, native_overlay_text, overlay_text_byteCount);
+                native_overlay_text[native_overlay_text_offset] = 0;
+            }
+            else { native_overlay_text = null; }
+            float scale_max = float.MaxValue;
+            Vector2 graph_size = new Vector2();
+            int stride = sizeof(float);
+            fixed (float* native_values = &values)
+            {
+                ImGuiNative.igPlotHistogram_FloatPtr(native_label, native_values, values_count, values_offset, native_overlay_text, scale_min, scale_max, graph_size, stride);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (overlay_text_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_overlay_text);
+                }
+            }
+        }
 #endif
+        public static void PlotHistogram(string label, ref float values, int values_count, int values_offset, string overlay_text, float scale_min)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -10592,9 +18830,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void PlotHistogram(ReadOnlySpan<char> label, ref float values, int values_count, int values_offset, ReadOnlySpan<char> overlay_text, float scale_min, float scale_max)
-#else
-        public static void PlotHistogram(string label, ref float values, int values_count, int values_offset, string overlay_text, float scale_min, float scale_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_overlay_text;
+            int overlay_text_byteCount = 0;
+            if (overlay_text != null)
+            {
+                overlay_text_byteCount = Encoding.UTF8.GetByteCount(overlay_text);
+                if (overlay_text_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_overlay_text = Util.Allocate(overlay_text_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_overlay_text_stackBytes = stackalloc byte[overlay_text_byteCount + 1];
+                    native_overlay_text = native_overlay_text_stackBytes;
+                }
+                int native_overlay_text_offset = Util.GetUtf8(overlay_text, native_overlay_text, overlay_text_byteCount);
+                native_overlay_text[native_overlay_text_offset] = 0;
+            }
+            else { native_overlay_text = null; }
+            Vector2 graph_size = new Vector2();
+            int stride = sizeof(float);
+            fixed (float* native_values = &values)
+            {
+                ImGuiNative.igPlotHistogram_FloatPtr(native_label, native_values, values_count, values_offset, native_overlay_text, scale_min, scale_max, graph_size, stride);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (overlay_text_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_overlay_text);
+                }
+            }
+        }
 #endif
+        public static void PlotHistogram(string label, ref float values, int values_count, int values_offset, string overlay_text, float scale_min, float scale_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -10649,9 +18938,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void PlotHistogram(ReadOnlySpan<char> label, ref float values, int values_count, int values_offset, ReadOnlySpan<char> overlay_text, float scale_min, float scale_max, Vector2 graph_size)
-#else
-        public static void PlotHistogram(string label, ref float values, int values_count, int values_offset, string overlay_text, float scale_min, float scale_max, Vector2 graph_size)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_overlay_text;
+            int overlay_text_byteCount = 0;
+            if (overlay_text != null)
+            {
+                overlay_text_byteCount = Encoding.UTF8.GetByteCount(overlay_text);
+                if (overlay_text_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_overlay_text = Util.Allocate(overlay_text_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_overlay_text_stackBytes = stackalloc byte[overlay_text_byteCount + 1];
+                    native_overlay_text = native_overlay_text_stackBytes;
+                }
+                int native_overlay_text_offset = Util.GetUtf8(overlay_text, native_overlay_text, overlay_text_byteCount);
+                native_overlay_text[native_overlay_text_offset] = 0;
+            }
+            else { native_overlay_text = null; }
+            int stride = sizeof(float);
+            fixed (float* native_values = &values)
+            {
+                ImGuiNative.igPlotHistogram_FloatPtr(native_label, native_values, values_count, values_offset, native_overlay_text, scale_min, scale_max, graph_size, stride);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (overlay_text_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_overlay_text);
+                }
+            }
+        }
 #endif
+        public static void PlotHistogram(string label, ref float values, int values_count, int values_offset, string overlay_text, float scale_min, float scale_max, Vector2 graph_size)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -10705,9 +19044,58 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void PlotHistogram(ReadOnlySpan<char> label, ref float values, int values_count, int values_offset, ReadOnlySpan<char> overlay_text, float scale_min, float scale_max, Vector2 graph_size, int stride)
-#else
-        public static void PlotHistogram(string label, ref float values, int values_count, int values_offset, string overlay_text, float scale_min, float scale_max, Vector2 graph_size, int stride)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_overlay_text;
+            int overlay_text_byteCount = 0;
+            if (overlay_text != null)
+            {
+                overlay_text_byteCount = Encoding.UTF8.GetByteCount(overlay_text);
+                if (overlay_text_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_overlay_text = Util.Allocate(overlay_text_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_overlay_text_stackBytes = stackalloc byte[overlay_text_byteCount + 1];
+                    native_overlay_text = native_overlay_text_stackBytes;
+                }
+                int native_overlay_text_offset = Util.GetUtf8(overlay_text, native_overlay_text, overlay_text_byteCount);
+                native_overlay_text[native_overlay_text_offset] = 0;
+            }
+            else { native_overlay_text = null; }
+            fixed (float* native_values = &values)
+            {
+                ImGuiNative.igPlotHistogram_FloatPtr(native_label, native_values, values_count, values_offset, native_overlay_text, scale_min, scale_max, graph_size, stride);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (overlay_text_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_overlay_text);
+                }
+            }
+        }
 #endif
+        public static void PlotHistogram(string label, ref float values, int values_count, int values_offset, string overlay_text, float scale_min, float scale_max, Vector2 graph_size, int stride)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -10760,9 +19148,42 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void PlotLines(ReadOnlySpan<char> label, ref float values, int values_count)
-#else
-        public static void PlotLines(string label, ref float values, int values_count)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            int values_offset = 0;
+            byte* native_overlay_text = null;
+            float scale_min = float.MaxValue;
+            float scale_max = float.MaxValue;
+            Vector2 graph_size = new Vector2();
+            int stride = sizeof(float);
+            fixed (float* native_values = &values)
+            {
+                ImGuiNative.igPlotLines_FloatPtr(native_label, native_values, values_count, values_offset, native_overlay_text, scale_min, scale_max, graph_size, stride);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+            }
+        }
 #endif
+        public static void PlotLines(string label, ref float values, int values_count)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -10799,9 +19220,41 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void PlotLines(ReadOnlySpan<char> label, ref float values, int values_count, int values_offset)
-#else
-        public static void PlotLines(string label, ref float values, int values_count, int values_offset)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_overlay_text = null;
+            float scale_min = float.MaxValue;
+            float scale_max = float.MaxValue;
+            Vector2 graph_size = new Vector2();
+            int stride = sizeof(float);
+            fixed (float* native_values = &values)
+            {
+                ImGuiNative.igPlotLines_FloatPtr(native_label, native_values, values_count, values_offset, native_overlay_text, scale_min, scale_max, graph_size, stride);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+            }
+        }
 #endif
+        public static void PlotLines(string label, ref float values, int values_count, int values_offset)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -10837,9 +19290,62 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void PlotLines(ReadOnlySpan<char> label, ref float values, int values_count, int values_offset, ReadOnlySpan<char> overlay_text)
-#else
-        public static void PlotLines(string label, ref float values, int values_count, int values_offset, string overlay_text)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_overlay_text;
+            int overlay_text_byteCount = 0;
+            if (overlay_text != null)
+            {
+                overlay_text_byteCount = Encoding.UTF8.GetByteCount(overlay_text);
+                if (overlay_text_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_overlay_text = Util.Allocate(overlay_text_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_overlay_text_stackBytes = stackalloc byte[overlay_text_byteCount + 1];
+                    native_overlay_text = native_overlay_text_stackBytes;
+                }
+                int native_overlay_text_offset = Util.GetUtf8(overlay_text, native_overlay_text, overlay_text_byteCount);
+                native_overlay_text[native_overlay_text_offset] = 0;
+            }
+            else { native_overlay_text = null; }
+            float scale_min = float.MaxValue;
+            float scale_max = float.MaxValue;
+            Vector2 graph_size = new Vector2();
+            int stride = sizeof(float);
+            fixed (float* native_values = &values)
+            {
+                ImGuiNative.igPlotLines_FloatPtr(native_label, native_values, values_count, values_offset, native_overlay_text, scale_min, scale_max, graph_size, stride);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (overlay_text_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_overlay_text);
+                }
+            }
+        }
 #endif
+        public static void PlotLines(string label, ref float values, int values_count, int values_offset, string overlay_text)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -10896,9 +19402,61 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void PlotLines(ReadOnlySpan<char> label, ref float values, int values_count, int values_offset, ReadOnlySpan<char> overlay_text, float scale_min)
-#else
-        public static void PlotLines(string label, ref float values, int values_count, int values_offset, string overlay_text, float scale_min)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_overlay_text;
+            int overlay_text_byteCount = 0;
+            if (overlay_text != null)
+            {
+                overlay_text_byteCount = Encoding.UTF8.GetByteCount(overlay_text);
+                if (overlay_text_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_overlay_text = Util.Allocate(overlay_text_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_overlay_text_stackBytes = stackalloc byte[overlay_text_byteCount + 1];
+                    native_overlay_text = native_overlay_text_stackBytes;
+                }
+                int native_overlay_text_offset = Util.GetUtf8(overlay_text, native_overlay_text, overlay_text_byteCount);
+                native_overlay_text[native_overlay_text_offset] = 0;
+            }
+            else { native_overlay_text = null; }
+            float scale_max = float.MaxValue;
+            Vector2 graph_size = new Vector2();
+            int stride = sizeof(float);
+            fixed (float* native_values = &values)
+            {
+                ImGuiNative.igPlotLines_FloatPtr(native_label, native_values, values_count, values_offset, native_overlay_text, scale_min, scale_max, graph_size, stride);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (overlay_text_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_overlay_text);
+                }
+            }
+        }
 #endif
+        public static void PlotLines(string label, ref float values, int values_count, int values_offset, string overlay_text, float scale_min)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -10954,9 +19512,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void PlotLines(ReadOnlySpan<char> label, ref float values, int values_count, int values_offset, ReadOnlySpan<char> overlay_text, float scale_min, float scale_max)
-#else
-        public static void PlotLines(string label, ref float values, int values_count, int values_offset, string overlay_text, float scale_min, float scale_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_overlay_text;
+            int overlay_text_byteCount = 0;
+            if (overlay_text != null)
+            {
+                overlay_text_byteCount = Encoding.UTF8.GetByteCount(overlay_text);
+                if (overlay_text_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_overlay_text = Util.Allocate(overlay_text_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_overlay_text_stackBytes = stackalloc byte[overlay_text_byteCount + 1];
+                    native_overlay_text = native_overlay_text_stackBytes;
+                }
+                int native_overlay_text_offset = Util.GetUtf8(overlay_text, native_overlay_text, overlay_text_byteCount);
+                native_overlay_text[native_overlay_text_offset] = 0;
+            }
+            else { native_overlay_text = null; }
+            Vector2 graph_size = new Vector2();
+            int stride = sizeof(float);
+            fixed (float* native_values = &values)
+            {
+                ImGuiNative.igPlotLines_FloatPtr(native_label, native_values, values_count, values_offset, native_overlay_text, scale_min, scale_max, graph_size, stride);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (overlay_text_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_overlay_text);
+                }
+            }
+        }
 #endif
+        public static void PlotLines(string label, ref float values, int values_count, int values_offset, string overlay_text, float scale_min, float scale_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -11011,9 +19620,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void PlotLines(ReadOnlySpan<char> label, ref float values, int values_count, int values_offset, ReadOnlySpan<char> overlay_text, float scale_min, float scale_max, Vector2 graph_size)
-#else
-        public static void PlotLines(string label, ref float values, int values_count, int values_offset, string overlay_text, float scale_min, float scale_max, Vector2 graph_size)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_overlay_text;
+            int overlay_text_byteCount = 0;
+            if (overlay_text != null)
+            {
+                overlay_text_byteCount = Encoding.UTF8.GetByteCount(overlay_text);
+                if (overlay_text_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_overlay_text = Util.Allocate(overlay_text_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_overlay_text_stackBytes = stackalloc byte[overlay_text_byteCount + 1];
+                    native_overlay_text = native_overlay_text_stackBytes;
+                }
+                int native_overlay_text_offset = Util.GetUtf8(overlay_text, native_overlay_text, overlay_text_byteCount);
+                native_overlay_text[native_overlay_text_offset] = 0;
+            }
+            else { native_overlay_text = null; }
+            int stride = sizeof(float);
+            fixed (float* native_values = &values)
+            {
+                ImGuiNative.igPlotLines_FloatPtr(native_label, native_values, values_count, values_offset, native_overlay_text, scale_min, scale_max, graph_size, stride);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (overlay_text_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_overlay_text);
+                }
+            }
+        }
 #endif
+        public static void PlotLines(string label, ref float values, int values_count, int values_offset, string overlay_text, float scale_min, float scale_max, Vector2 graph_size)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -11067,9 +19726,58 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void PlotLines(ReadOnlySpan<char> label, ref float values, int values_count, int values_offset, ReadOnlySpan<char> overlay_text, float scale_min, float scale_max, Vector2 graph_size, int stride)
-#else
-        public static void PlotLines(string label, ref float values, int values_count, int values_offset, string overlay_text, float scale_min, float scale_max, Vector2 graph_size, int stride)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_overlay_text;
+            int overlay_text_byteCount = 0;
+            if (overlay_text != null)
+            {
+                overlay_text_byteCount = Encoding.UTF8.GetByteCount(overlay_text);
+                if (overlay_text_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_overlay_text = Util.Allocate(overlay_text_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_overlay_text_stackBytes = stackalloc byte[overlay_text_byteCount + 1];
+                    native_overlay_text = native_overlay_text_stackBytes;
+                }
+                int native_overlay_text_offset = Util.GetUtf8(overlay_text, native_overlay_text, overlay_text_byteCount);
+                native_overlay_text[native_overlay_text_offset] = 0;
+            }
+            else { native_overlay_text = null; }
+            fixed (float* native_values = &values)
+            {
+                ImGuiNative.igPlotLines_FloatPtr(native_label, native_values, values_count, values_offset, native_overlay_text, scale_min, scale_max, graph_size, stride);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (overlay_text_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_overlay_text);
+                }
+            }
+        }
 #endif
+        public static void PlotLines(string label, ref float values, int values_count, int values_offset, string overlay_text, float scale_min, float scale_max, Vector2 graph_size, int stride)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -11179,9 +19887,33 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void ProgressBar(float fraction, Vector2 size_arg, ReadOnlySpan<char> overlay)
-#else
-        public static void ProgressBar(float fraction, Vector2 size_arg, string overlay)
+        {
+            byte* native_overlay;
+            int overlay_byteCount = 0;
+            if (overlay != null)
+            {
+                overlay_byteCount = Encoding.UTF8.GetByteCount(overlay);
+                if (overlay_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_overlay = Util.Allocate(overlay_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_overlay_stackBytes = stackalloc byte[overlay_byteCount + 1];
+                    native_overlay = native_overlay_stackBytes;
+                }
+                int native_overlay_offset = Util.GetUtf8(overlay, native_overlay, overlay_byteCount);
+                native_overlay[native_overlay_offset] = 0;
+            }
+            else { native_overlay = null; }
+            ImGuiNative.igProgressBar(fraction, size_arg, native_overlay);
+            if (overlay_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_overlay);
+            }
+        }
 #endif
+        public static void ProgressBar(float fraction, Vector2 size_arg, string overlay)
         {
             byte* native_overlay;
             int overlay_byteCount = 0;
@@ -11224,9 +19956,33 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void PushID(ReadOnlySpan<char> str_id)
-#else
-        public static void PushID(string str_id)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            ImGuiNative.igPushID_Str(native_str_id);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+        }
 #endif
+        public static void PushID(string str_id)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -11297,9 +20053,35 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool RadioButton(ReadOnlySpan<char> label, bool active)
-#else
-        public static bool RadioButton(string label, bool active)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte native_active = active ? (byte)1 : (byte)0;
+            byte ret = ImGuiNative.igRadioButton_Bool(native_label, native_active);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool RadioButton(string label, bool active)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -11329,9 +20111,37 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool RadioButton(ReadOnlySpan<char> label, ref int v, int v_button)
-#else
-        public static bool RadioButton(string label, ref int v, int v_button)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igRadioButton_IntPtr(native_label, native_v, v_button);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool RadioButton(string label, ref int v, int v_button)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -11409,9 +20219,33 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void SaveIniSettingsToDisk(ReadOnlySpan<char> ini_filename)
-#else
-        public static void SaveIniSettingsToDisk(string ini_filename)
+        {
+            byte* native_ini_filename;
+            int ini_filename_byteCount = 0;
+            if (ini_filename != null)
+            {
+                ini_filename_byteCount = Encoding.UTF8.GetByteCount(ini_filename);
+                if (ini_filename_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_ini_filename = Util.Allocate(ini_filename_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_ini_filename_stackBytes = stackalloc byte[ini_filename_byteCount + 1];
+                    native_ini_filename = native_ini_filename_stackBytes;
+                }
+                int native_ini_filename_offset = Util.GetUtf8(ini_filename, native_ini_filename, ini_filename_byteCount);
+                native_ini_filename[native_ini_filename_offset] = 0;
+            }
+            else { native_ini_filename = null; }
+            ImGuiNative.igSaveIniSettingsToDisk(native_ini_filename);
+            if (ini_filename_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_ini_filename);
+            }
+        }
 #endif
+        public static void SaveIniSettingsToDisk(string ini_filename)
         {
             byte* native_ini_filename;
             int ini_filename_byteCount = 0;
@@ -11453,9 +20287,37 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Selectable(ReadOnlySpan<char> label)
-#else
-        public static bool Selectable(string label)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte selected = 0;
+            ImGuiSelectableFlags flags = (ImGuiSelectableFlags)0;
+            Vector2 size = new Vector2();
+            byte ret = ImGuiNative.igSelectable_Bool(native_label, selected, flags, size);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool Selectable(string label)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -11487,9 +20349,37 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Selectable(ReadOnlySpan<char> label, bool selected)
-#else
-        public static bool Selectable(string label, bool selected)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte native_selected = selected ? (byte)1 : (byte)0;
+            ImGuiSelectableFlags flags = (ImGuiSelectableFlags)0;
+            Vector2 size = new Vector2();
+            byte ret = ImGuiNative.igSelectable_Bool(native_label, native_selected, flags, size);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool Selectable(string label, bool selected)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -11521,9 +20411,36 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Selectable(ReadOnlySpan<char> label, bool selected, ImGuiSelectableFlags flags)
-#else
-        public static bool Selectable(string label, bool selected, ImGuiSelectableFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte native_selected = selected ? (byte)1 : (byte)0;
+            Vector2 size = new Vector2();
+            byte ret = ImGuiNative.igSelectable_Bool(native_label, native_selected, flags, size);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool Selectable(string label, bool selected, ImGuiSelectableFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -11554,9 +20471,35 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Selectable(ReadOnlySpan<char> label, bool selected, ImGuiSelectableFlags flags, Vector2 size)
-#else
-        public static bool Selectable(string label, bool selected, ImGuiSelectableFlags flags, Vector2 size)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte native_selected = selected ? (byte)1 : (byte)0;
+            byte ret = ImGuiNative.igSelectable_Bool(native_label, native_selected, flags, size);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool Selectable(string label, bool selected, ImGuiSelectableFlags flags, Vector2 size)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -11586,9 +20529,39 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Selectable(ReadOnlySpan<char> label, ref bool p_selected)
-#else
-        public static bool Selectable(string label, ref bool p_selected)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte native_p_selected_val = p_selected ? (byte)1 : (byte)0;
+            byte* native_p_selected = &native_p_selected_val;
+            ImGuiSelectableFlags flags = (ImGuiSelectableFlags)0;
+            Vector2 size = new Vector2();
+            byte ret = ImGuiNative.igSelectable_BoolPtr(native_label, native_p_selected, flags, size);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            p_selected = native_p_selected_val != 0;
+            return ret != 0;
+        }
 #endif
+        public static bool Selectable(string label, ref bool p_selected)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -11622,9 +20595,38 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Selectable(ReadOnlySpan<char> label, ref bool p_selected, ImGuiSelectableFlags flags)
-#else
-        public static bool Selectable(string label, ref bool p_selected, ImGuiSelectableFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte native_p_selected_val = p_selected ? (byte)1 : (byte)0;
+            byte* native_p_selected = &native_p_selected_val;
+            Vector2 size = new Vector2();
+            byte ret = ImGuiNative.igSelectable_BoolPtr(native_label, native_p_selected, flags, size);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            p_selected = native_p_selected_val != 0;
+            return ret != 0;
+        }
 #endif
+        public static bool Selectable(string label, ref bool p_selected, ImGuiSelectableFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -11657,9 +20659,37 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool Selectable(ReadOnlySpan<char> label, ref bool p_selected, ImGuiSelectableFlags flags, Vector2 size)
-#else
-        public static bool Selectable(string label, ref bool p_selected, ImGuiSelectableFlags flags, Vector2 size)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte native_p_selected_val = p_selected ? (byte)1 : (byte)0;
+            byte* native_p_selected = &native_p_selected_val;
+            byte ret = ImGuiNative.igSelectable_BoolPtr(native_label, native_p_selected, flags, size);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            p_selected = native_p_selected_val != 0;
+            return ret != 0;
+        }
 #endif
+        public static bool Selectable(string label, ref bool p_selected, ImGuiSelectableFlags flags, Vector2 size)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -11695,9 +20725,33 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void SeparatorText(ReadOnlySpan<char> label)
-#else
-        public static void SeparatorText(string label)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            ImGuiNative.igSeparatorText(native_label);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+        }
 #endif
+        public static void SeparatorText(string label)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -11735,9 +20789,33 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void SetClipboardText(ReadOnlySpan<char> text)
-#else
-        public static void SetClipboardText(string text)
+        {
+            byte* native_text;
+            int text_byteCount = 0;
+            if (text != null)
+            {
+                text_byteCount = Encoding.UTF8.GetByteCount(text);
+                if (text_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_text = Util.Allocate(text_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_text_stackBytes = stackalloc byte[text_byteCount + 1];
+                    native_text = native_text_stackBytes;
+                }
+                int native_text_offset = Util.GetUtf8(text, native_text, text_byteCount);
+                native_text[native_text_offset] = 0;
+            }
+            else { native_text = null; }
+            ImGuiNative.igSetClipboardText(native_text);
+            if (text_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_text);
+            }
+        }
 #endif
+        public static void SetClipboardText(string text)
         {
             byte* native_text;
             int text_byteCount = 0;
@@ -11797,9 +20875,36 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SetDragDropPayload(ReadOnlySpan<char> type, IntPtr data, uint sz)
-#else
-        public static bool SetDragDropPayload(string type, IntPtr data, uint sz)
+        {
+            byte* native_type;
+            int type_byteCount = 0;
+            if (type != null)
+            {
+                type_byteCount = Encoding.UTF8.GetByteCount(type);
+                if (type_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_type = Util.Allocate(type_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_type_stackBytes = stackalloc byte[type_byteCount + 1];
+                    native_type = native_type_stackBytes;
+                }
+                int native_type_offset = Util.GetUtf8(type, native_type, type_byteCount);
+                native_type[native_type_offset] = 0;
+            }
+            else { native_type = null; }
+            void* native_data = (void*)data.ToPointer();
+            ImGuiCond cond = (ImGuiCond)0;
+            byte ret = ImGuiNative.igSetDragDropPayload(native_type, native_data, sz, cond);
+            if (type_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_type);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool SetDragDropPayload(string type, IntPtr data, uint sz)
         {
             byte* native_type;
             int type_byteCount = 0;
@@ -11830,9 +20935,35 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SetDragDropPayload(ReadOnlySpan<char> type, IntPtr data, uint sz, ImGuiCond cond)
-#else
-        public static bool SetDragDropPayload(string type, IntPtr data, uint sz, ImGuiCond cond)
+        {
+            byte* native_type;
+            int type_byteCount = 0;
+            if (type != null)
+            {
+                type_byteCount = Encoding.UTF8.GetByteCount(type);
+                if (type_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_type = Util.Allocate(type_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_type_stackBytes = stackalloc byte[type_byteCount + 1];
+                    native_type = native_type_stackBytes;
+                }
+                int native_type_offset = Util.GetUtf8(type, native_type, type_byteCount);
+                native_type[native_type_offset] = 0;
+            }
+            else { native_type = null; }
+            void* native_data = (void*)data.ToPointer();
+            byte ret = ImGuiNative.igSetDragDropPayload(native_type, native_data, sz, cond);
+            if (type_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_type);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool SetDragDropPayload(string type, IntPtr data, uint sz, ImGuiCond cond)
         {
             byte* native_type;
             int type_byteCount = 0;
@@ -11866,9 +20997,33 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void SetItemTooltip(ReadOnlySpan<char> fmt)
-#else
-        public static void SetItemTooltip(string fmt)
+        {
+            byte* native_fmt;
+            int fmt_byteCount = 0;
+            if (fmt != null)
+            {
+                fmt_byteCount = Encoding.UTF8.GetByteCount(fmt);
+                if (fmt_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_fmt = Util.Allocate(fmt_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_fmt_stackBytes = stackalloc byte[fmt_byteCount + 1];
+                    native_fmt = native_fmt_stackBytes;
+                }
+                int native_fmt_offset = Util.GetUtf8(fmt, native_fmt, fmt_byteCount);
+                native_fmt[native_fmt_offset] = 0;
+            }
+            else { native_fmt = null; }
+            ImGuiNative.igSetItemTooltip(native_fmt);
+            if (fmt_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_fmt);
+            }
+        }
 #endif
+        public static void SetItemTooltip(string fmt)
         {
             byte* native_fmt;
             int fmt_byteCount = 0;
@@ -12072,9 +21227,33 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void SetTabItemClosed(ReadOnlySpan<char> tab_or_docked_window_label)
-#else
-        public static void SetTabItemClosed(string tab_or_docked_window_label)
+        {
+            byte* native_tab_or_docked_window_label;
+            int tab_or_docked_window_label_byteCount = 0;
+            if (tab_or_docked_window_label != null)
+            {
+                tab_or_docked_window_label_byteCount = Encoding.UTF8.GetByteCount(tab_or_docked_window_label);
+                if (tab_or_docked_window_label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_tab_or_docked_window_label = Util.Allocate(tab_or_docked_window_label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_tab_or_docked_window_label_stackBytes = stackalloc byte[tab_or_docked_window_label_byteCount + 1];
+                    native_tab_or_docked_window_label = native_tab_or_docked_window_label_stackBytes;
+                }
+                int native_tab_or_docked_window_label_offset = Util.GetUtf8(tab_or_docked_window_label, native_tab_or_docked_window_label, tab_or_docked_window_label_byteCount);
+                native_tab_or_docked_window_label[native_tab_or_docked_window_label_offset] = 0;
+            }
+            else { native_tab_or_docked_window_label = null; }
+            ImGuiNative.igSetTabItemClosed(native_tab_or_docked_window_label);
+            if (tab_or_docked_window_label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_tab_or_docked_window_label);
+            }
+        }
 #endif
+        public static void SetTabItemClosed(string tab_or_docked_window_label)
         {
             byte* native_tab_or_docked_window_label;
             int tab_or_docked_window_label_byteCount = 0;
@@ -12102,9 +21281,33 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void SetTooltip(ReadOnlySpan<char> fmt)
-#else
-        public static void SetTooltip(string fmt)
+        {
+            byte* native_fmt;
+            int fmt_byteCount = 0;
+            if (fmt != null)
+            {
+                fmt_byteCount = Encoding.UTF8.GetByteCount(fmt);
+                if (fmt_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_fmt = Util.Allocate(fmt_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_fmt_stackBytes = stackalloc byte[fmt_byteCount + 1];
+                    native_fmt = native_fmt_stackBytes;
+                }
+                int native_fmt_offset = Util.GetUtf8(fmt, native_fmt, fmt_byteCount);
+                native_fmt[native_fmt_offset] = 0;
+            }
+            else { native_fmt = null; }
+            ImGuiNative.igSetTooltip(native_fmt);
+            if (fmt_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_fmt);
+            }
+        }
 #endif
+        public static void SetTooltip(string fmt)
         {
             byte* native_fmt;
             int fmt_byteCount = 0;
@@ -12143,9 +21346,35 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void SetWindowCollapsed(ReadOnlySpan<char> name, bool collapsed)
-#else
-        public static void SetWindowCollapsed(string name, bool collapsed)
+        {
+            byte* native_name;
+            int name_byteCount = 0;
+            if (name != null)
+            {
+                name_byteCount = Encoding.UTF8.GetByteCount(name);
+                if (name_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_name = Util.Allocate(name_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_name_stackBytes = stackalloc byte[name_byteCount + 1];
+                    native_name = native_name_stackBytes;
+                }
+                int native_name_offset = Util.GetUtf8(name, native_name, name_byteCount);
+                native_name[native_name_offset] = 0;
+            }
+            else { native_name = null; }
+            byte native_collapsed = collapsed ? (byte)1 : (byte)0;
+            ImGuiCond cond = (ImGuiCond)0;
+            ImGuiNative.igSetWindowCollapsed_Str(native_name, native_collapsed, cond);
+            if (name_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_name);
+            }
+        }
 #endif
+        public static void SetWindowCollapsed(string name, bool collapsed)
         {
             byte* native_name;
             int name_byteCount = 0;
@@ -12175,9 +21404,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void SetWindowCollapsed(ReadOnlySpan<char> name, bool collapsed, ImGuiCond cond)
-#else
-        public static void SetWindowCollapsed(string name, bool collapsed, ImGuiCond cond)
+        {
+            byte* native_name;
+            int name_byteCount = 0;
+            if (name != null)
+            {
+                name_byteCount = Encoding.UTF8.GetByteCount(name);
+                if (name_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_name = Util.Allocate(name_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_name_stackBytes = stackalloc byte[name_byteCount + 1];
+                    native_name = native_name_stackBytes;
+                }
+                int native_name_offset = Util.GetUtf8(name, native_name, name_byteCount);
+                native_name[native_name_offset] = 0;
+            }
+            else { native_name = null; }
+            byte native_collapsed = collapsed ? (byte)1 : (byte)0;
+            ImGuiNative.igSetWindowCollapsed_Str(native_name, native_collapsed, cond);
+            if (name_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_name);
+            }
+        }
 #endif
+        public static void SetWindowCollapsed(string name, bool collapsed, ImGuiCond cond)
         {
             byte* native_name;
             int name_byteCount = 0;
@@ -12210,9 +21464,33 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void SetWindowFocus(ReadOnlySpan<char> name)
-#else
-        public static void SetWindowFocus(string name)
+        {
+            byte* native_name;
+            int name_byteCount = 0;
+            if (name != null)
+            {
+                name_byteCount = Encoding.UTF8.GetByteCount(name);
+                if (name_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_name = Util.Allocate(name_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_name_stackBytes = stackalloc byte[name_byteCount + 1];
+                    native_name = native_name_stackBytes;
+                }
+                int native_name_offset = Util.GetUtf8(name, native_name, name_byteCount);
+                native_name[native_name_offset] = 0;
+            }
+            else { native_name = null; }
+            ImGuiNative.igSetWindowFocus_Str(native_name);
+            if (name_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_name);
+            }
+        }
 #endif
+        public static void SetWindowFocus(string name)
         {
             byte* native_name;
             int name_byteCount = 0;
@@ -12253,9 +21531,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void SetWindowPos(ReadOnlySpan<char> name, Vector2 pos)
-#else
-        public static void SetWindowPos(string name, Vector2 pos)
+        {
+            byte* native_name;
+            int name_byteCount = 0;
+            if (name != null)
+            {
+                name_byteCount = Encoding.UTF8.GetByteCount(name);
+                if (name_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_name = Util.Allocate(name_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_name_stackBytes = stackalloc byte[name_byteCount + 1];
+                    native_name = native_name_stackBytes;
+                }
+                int native_name_offset = Util.GetUtf8(name, native_name, name_byteCount);
+                native_name[native_name_offset] = 0;
+            }
+            else { native_name = null; }
+            ImGuiCond cond = (ImGuiCond)0;
+            ImGuiNative.igSetWindowPos_Str(native_name, pos, cond);
+            if (name_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_name);
+            }
+        }
 #endif
+        public static void SetWindowPos(string name, Vector2 pos)
         {
             byte* native_name;
             int name_byteCount = 0;
@@ -12284,9 +21587,33 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void SetWindowPos(ReadOnlySpan<char> name, Vector2 pos, ImGuiCond cond)
-#else
-        public static void SetWindowPos(string name, Vector2 pos, ImGuiCond cond)
+        {
+            byte* native_name;
+            int name_byteCount = 0;
+            if (name != null)
+            {
+                name_byteCount = Encoding.UTF8.GetByteCount(name);
+                if (name_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_name = Util.Allocate(name_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_name_stackBytes = stackalloc byte[name_byteCount + 1];
+                    native_name = native_name_stackBytes;
+                }
+                int native_name_offset = Util.GetUtf8(name, native_name, name_byteCount);
+                native_name[native_name_offset] = 0;
+            }
+            else { native_name = null; }
+            ImGuiNative.igSetWindowPos_Str(native_name, pos, cond);
+            if (name_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_name);
+            }
+        }
 #endif
+        public static void SetWindowPos(string name, Vector2 pos, ImGuiCond cond)
         {
             byte* native_name;
             int name_byteCount = 0;
@@ -12323,9 +21650,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void SetWindowSize(ReadOnlySpan<char> name, Vector2 size)
-#else
-        public static void SetWindowSize(string name, Vector2 size)
+        {
+            byte* native_name;
+            int name_byteCount = 0;
+            if (name != null)
+            {
+                name_byteCount = Encoding.UTF8.GetByteCount(name);
+                if (name_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_name = Util.Allocate(name_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_name_stackBytes = stackalloc byte[name_byteCount + 1];
+                    native_name = native_name_stackBytes;
+                }
+                int native_name_offset = Util.GetUtf8(name, native_name, name_byteCount);
+                native_name[native_name_offset] = 0;
+            }
+            else { native_name = null; }
+            ImGuiCond cond = (ImGuiCond)0;
+            ImGuiNative.igSetWindowSize_Str(native_name, size, cond);
+            if (name_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_name);
+            }
+        }
 #endif
+        public static void SetWindowSize(string name, Vector2 size)
         {
             byte* native_name;
             int name_byteCount = 0;
@@ -12354,9 +21706,33 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void SetWindowSize(ReadOnlySpan<char> name, Vector2 size, ImGuiCond cond)
-#else
-        public static void SetWindowSize(string name, Vector2 size, ImGuiCond cond)
+        {
+            byte* native_name;
+            int name_byteCount = 0;
+            if (name != null)
+            {
+                name_byteCount = Encoding.UTF8.GetByteCount(name);
+                if (name_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_name = Util.Allocate(name_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_name_stackBytes = stackalloc byte[name_byteCount + 1];
+                    native_name = native_name_stackBytes;
+                }
+                int native_name_offset = Util.GetUtf8(name, native_name, name_byteCount);
+                native_name[native_name_offset] = 0;
+            }
+            else { native_name = null; }
+            ImGuiNative.igSetWindowSize_Str(native_name, size, cond);
+            if (name_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_name);
+            }
+        }
 #endif
+        public static void SetWindowSize(string name, Vector2 size, ImGuiCond cond)
         {
             byte* native_name;
             int name_byteCount = 0;
@@ -12420,9 +21796,33 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void ShowFontSelector(ReadOnlySpan<char> label)
-#else
-        public static void ShowFontSelector(string label)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            ImGuiNative.igShowFontSelector(native_label);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+        }
 #endif
+        public static void ShowFontSelector(string label)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -12484,9 +21884,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool ShowStyleSelector(ReadOnlySpan<char> label)
-#else
-        public static bool ShowStyleSelector(string label)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte ret = ImGuiNative.igShowStyleSelector(native_label);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool ShowStyleSelector(string label)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -12519,9 +21944,58 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderAngle(ReadOnlySpan<char> label, ref float v_rad)
-#else
-        public static bool SliderAngle(string label, ref float v_rad)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            float v_degrees_min = -360.0f;
+            float v_degrees_max = +360.0f;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.0f deg");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.0f deg", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (float* native_v_rad = &v_rad)
+            {
+                byte ret = ImGuiNative.igSliderAngle(native_label, native_v_rad, v_degrees_min, v_degrees_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool SliderAngle(string label, ref float v_rad)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -12574,9 +22048,57 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderAngle(ReadOnlySpan<char> label, ref float v_rad, float v_degrees_min)
-#else
-        public static bool SliderAngle(string label, ref float v_rad, float v_degrees_min)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            float v_degrees_max = +360.0f;
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.0f deg");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.0f deg", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (float* native_v_rad = &v_rad)
+            {
+                byte ret = ImGuiNative.igSliderAngle(native_label, native_v_rad, v_degrees_min, v_degrees_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool SliderAngle(string label, ref float v_rad, float v_degrees_min)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -12628,9 +22150,56 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderAngle(ReadOnlySpan<char> label, ref float v_rad, float v_degrees_min, float v_degrees_max)
-#else
-        public static bool SliderAngle(string label, ref float v_rad, float v_degrees_min, float v_degrees_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.0f deg");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.0f deg", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (float* native_v_rad = &v_rad)
+            {
+                byte ret = ImGuiNative.igSliderAngle(native_label, native_v_rad, v_degrees_min, v_degrees_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool SliderAngle(string label, ref float v_rad, float v_degrees_min, float v_degrees_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -12681,9 +22250,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderAngle(ReadOnlySpan<char> label, ref float v_rad, float v_degrees_min, float v_degrees_max, ReadOnlySpan<char> format)
-#else
-        public static bool SliderAngle(string label, ref float v_rad, float v_degrees_min, float v_degrees_max, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (float* native_v_rad = &v_rad)
+            {
+                byte ret = ImGuiNative.igSliderAngle(native_label, native_v_rad, v_degrees_min, v_degrees_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool SliderAngle(string label, ref float v_rad, float v_degrees_min, float v_degrees_max, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -12738,9 +22358,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderAngle(ReadOnlySpan<char> label, ref float v_rad, float v_degrees_min, float v_degrees_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool SliderAngle(string label, ref float v_rad, float v_degrees_min, float v_degrees_max, string format, ImGuiSliderFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            fixed (float* native_v_rad = &v_rad)
+            {
+                byte ret = ImGuiNative.igSliderAngle(native_label, native_v_rad, v_degrees_min, v_degrees_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool SliderAngle(string label, ref float v_rad, float v_degrees_min, float v_degrees_max, string format, ImGuiSliderFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -12794,9 +22464,56 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderFloat(ReadOnlySpan<char> label, ref float v, float v_min, float v_max)
-#else
-        public static bool SliderFloat(string label, ref float v, float v_min, float v_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.3f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (float* native_v = &v)
+            {
+                byte ret = ImGuiNative.igSliderFloat(native_label, native_v, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool SliderFloat(string label, ref float v, float v_min, float v_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -12847,9 +22564,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderFloat(ReadOnlySpan<char> label, ref float v, float v_min, float v_max, ReadOnlySpan<char> format)
-#else
-        public static bool SliderFloat(string label, ref float v, float v_min, float v_max, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (float* native_v = &v)
+            {
+                byte ret = ImGuiNative.igSliderFloat(native_label, native_v, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool SliderFloat(string label, ref float v, float v_min, float v_max, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -12904,9 +22672,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderFloat(ReadOnlySpan<char> label, ref float v, float v_min, float v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool SliderFloat(string label, ref float v, float v_min, float v_max, string format, ImGuiSliderFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            fixed (float* native_v = &v)
+            {
+                byte ret = ImGuiNative.igSliderFloat(native_label, native_v, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool SliderFloat(string label, ref float v, float v_min, float v_max, string format, ImGuiSliderFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -12960,9 +22778,56 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderFloat2(ReadOnlySpan<char> label, ref Vector2 v, float v_min, float v_max)
-#else
-        public static bool SliderFloat2(string label, ref Vector2 v, float v_min, float v_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.3f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (Vector2* native_v = &v)
+            {
+                byte ret = ImGuiNative.igSliderFloat2(native_label, native_v, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool SliderFloat2(string label, ref Vector2 v, float v_min, float v_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -13013,9 +22878,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderFloat2(ReadOnlySpan<char> label, ref Vector2 v, float v_min, float v_max, ReadOnlySpan<char> format)
-#else
-        public static bool SliderFloat2(string label, ref Vector2 v, float v_min, float v_max, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (Vector2* native_v = &v)
+            {
+                byte ret = ImGuiNative.igSliderFloat2(native_label, native_v, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool SliderFloat2(string label, ref Vector2 v, float v_min, float v_max, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -13070,9 +22986,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderFloat2(ReadOnlySpan<char> label, ref Vector2 v, float v_min, float v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool SliderFloat2(string label, ref Vector2 v, float v_min, float v_max, string format, ImGuiSliderFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            fixed (Vector2* native_v = &v)
+            {
+                byte ret = ImGuiNative.igSliderFloat2(native_label, native_v, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool SliderFloat2(string label, ref Vector2 v, float v_min, float v_max, string format, ImGuiSliderFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -13126,9 +23092,56 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderFloat3(ReadOnlySpan<char> label, ref Vector3 v, float v_min, float v_max)
-#else
-        public static bool SliderFloat3(string label, ref Vector3 v, float v_min, float v_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.3f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (Vector3* native_v = &v)
+            {
+                byte ret = ImGuiNative.igSliderFloat3(native_label, native_v, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool SliderFloat3(string label, ref Vector3 v, float v_min, float v_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -13179,9 +23192,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderFloat3(ReadOnlySpan<char> label, ref Vector3 v, float v_min, float v_max, ReadOnlySpan<char> format)
-#else
-        public static bool SliderFloat3(string label, ref Vector3 v, float v_min, float v_max, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (Vector3* native_v = &v)
+            {
+                byte ret = ImGuiNative.igSliderFloat3(native_label, native_v, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool SliderFloat3(string label, ref Vector3 v, float v_min, float v_max, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -13236,9 +23300,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderFloat3(ReadOnlySpan<char> label, ref Vector3 v, float v_min, float v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool SliderFloat3(string label, ref Vector3 v, float v_min, float v_max, string format, ImGuiSliderFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            fixed (Vector3* native_v = &v)
+            {
+                byte ret = ImGuiNative.igSliderFloat3(native_label, native_v, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool SliderFloat3(string label, ref Vector3 v, float v_min, float v_max, string format, ImGuiSliderFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -13292,9 +23406,56 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderFloat4(ReadOnlySpan<char> label, ref Vector4 v, float v_min, float v_max)
-#else
-        public static bool SliderFloat4(string label, ref Vector4 v, float v_min, float v_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.3f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (Vector4* native_v = &v)
+            {
+                byte ret = ImGuiNative.igSliderFloat4(native_label, native_v, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool SliderFloat4(string label, ref Vector4 v, float v_min, float v_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -13345,9 +23506,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderFloat4(ReadOnlySpan<char> label, ref Vector4 v, float v_min, float v_max, ReadOnlySpan<char> format)
-#else
-        public static bool SliderFloat4(string label, ref Vector4 v, float v_min, float v_max, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (Vector4* native_v = &v)
+            {
+                byte ret = ImGuiNative.igSliderFloat4(native_label, native_v, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool SliderFloat4(string label, ref Vector4 v, float v_min, float v_max, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -13402,9 +23614,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderFloat4(ReadOnlySpan<char> label, ref Vector4 v, float v_min, float v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool SliderFloat4(string label, ref Vector4 v, float v_min, float v_max, string format, ImGuiSliderFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            fixed (Vector4* native_v = &v)
+            {
+                byte ret = ImGuiNative.igSliderFloat4(native_label, native_v, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool SliderFloat4(string label, ref Vector4 v, float v_min, float v_max, string format, ImGuiSliderFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -13458,9 +23720,56 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderInt(ReadOnlySpan<char> label, ref int v, int v_min, int v_max)
-#else
-        public static bool SliderInt(string label, ref int v, int v_min, int v_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%d", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igSliderInt(native_label, native_v, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool SliderInt(string label, ref int v, int v_min, int v_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -13511,9 +23820,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderInt(ReadOnlySpan<char> label, ref int v, int v_min, int v_max, ReadOnlySpan<char> format)
-#else
-        public static bool SliderInt(string label, ref int v, int v_min, int v_max, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igSliderInt(native_label, native_v, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool SliderInt(string label, ref int v, int v_min, int v_max, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -13568,9 +23928,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderInt(ReadOnlySpan<char> label, ref int v, int v_min, int v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool SliderInt(string label, ref int v, int v_min, int v_max, string format, ImGuiSliderFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igSliderInt(native_label, native_v, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool SliderInt(string label, ref int v, int v_min, int v_max, string format, ImGuiSliderFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -13624,9 +24034,56 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderInt2(ReadOnlySpan<char> label, ref int v, int v_min, int v_max)
-#else
-        public static bool SliderInt2(string label, ref int v, int v_min, int v_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%d", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igSliderInt2(native_label, native_v, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool SliderInt2(string label, ref int v, int v_min, int v_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -13677,9 +24134,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderInt2(ReadOnlySpan<char> label, ref int v, int v_min, int v_max, ReadOnlySpan<char> format)
-#else
-        public static bool SliderInt2(string label, ref int v, int v_min, int v_max, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igSliderInt2(native_label, native_v, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool SliderInt2(string label, ref int v, int v_min, int v_max, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -13734,9 +24242,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderInt2(ReadOnlySpan<char> label, ref int v, int v_min, int v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool SliderInt2(string label, ref int v, int v_min, int v_max, string format, ImGuiSliderFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igSliderInt2(native_label, native_v, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool SliderInt2(string label, ref int v, int v_min, int v_max, string format, ImGuiSliderFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -13790,9 +24348,56 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderInt3(ReadOnlySpan<char> label, ref int v, int v_min, int v_max)
-#else
-        public static bool SliderInt3(string label, ref int v, int v_min, int v_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%d", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igSliderInt3(native_label, native_v, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool SliderInt3(string label, ref int v, int v_min, int v_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -13843,9 +24448,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderInt3(ReadOnlySpan<char> label, ref int v, int v_min, int v_max, ReadOnlySpan<char> format)
-#else
-        public static bool SliderInt3(string label, ref int v, int v_min, int v_max, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igSliderInt3(native_label, native_v, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool SliderInt3(string label, ref int v, int v_min, int v_max, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -13900,9 +24556,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderInt3(ReadOnlySpan<char> label, ref int v, int v_min, int v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool SliderInt3(string label, ref int v, int v_min, int v_max, string format, ImGuiSliderFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igSliderInt3(native_label, native_v, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool SliderInt3(string label, ref int v, int v_min, int v_max, string format, ImGuiSliderFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -13956,9 +24662,56 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderInt4(ReadOnlySpan<char> label, ref int v, int v_min, int v_max)
-#else
-        public static bool SliderInt4(string label, ref int v, int v_min, int v_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%d", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igSliderInt4(native_label, native_v, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool SliderInt4(string label, ref int v, int v_min, int v_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -14009,9 +24762,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderInt4(ReadOnlySpan<char> label, ref int v, int v_min, int v_max, ReadOnlySpan<char> format)
-#else
-        public static bool SliderInt4(string label, ref int v, int v_min, int v_max, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igSliderInt4(native_label, native_v, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool SliderInt4(string label, ref int v, int v_min, int v_max, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -14066,9 +24870,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderInt4(ReadOnlySpan<char> label, ref int v, int v_min, int v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool SliderInt4(string label, ref int v, int v_min, int v_max, string format, ImGuiSliderFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igSliderInt4(native_label, native_v, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool SliderInt4(string label, ref int v, int v_min, int v_max, string format, ImGuiSliderFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -14122,9 +24976,39 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderScalar(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_min, IntPtr p_max)
-#else
-        public static bool SliderScalar(string label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_min, IntPtr p_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            void* native_p_data = (void*)p_data.ToPointer();
+            void* native_p_min = (void*)p_min.ToPointer();
+            void* native_p_max = (void*)p_max.ToPointer();
+            byte* native_format = null;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            byte ret = ImGuiNative.igSliderScalar(native_label, data_type, native_p_data, native_p_min, native_p_max, native_format, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool SliderScalar(string label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_min, IntPtr p_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -14158,9 +25042,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderScalar(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_min, IntPtr p_max, ReadOnlySpan<char> format)
-#else
-        public static bool SliderScalar(string label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_min, IntPtr p_max, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            void* native_p_data = (void*)p_data.ToPointer();
+            void* native_p_min = (void*)p_min.ToPointer();
+            void* native_p_max = (void*)p_max.ToPointer();
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            byte ret = ImGuiNative.igSliderScalar(native_label, data_type, native_p_data, native_p_min, native_p_max, native_format, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            if (format_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_format);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool SliderScalar(string label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_min, IntPtr p_max, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -14215,9 +25150,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderScalar(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_min, IntPtr p_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool SliderScalar(string label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_min, IntPtr p_max, string format, ImGuiSliderFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            void* native_p_data = (void*)p_data.ToPointer();
+            void* native_p_min = (void*)p_min.ToPointer();
+            void* native_p_max = (void*)p_max.ToPointer();
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            byte ret = ImGuiNative.igSliderScalar(native_label, data_type, native_p_data, native_p_min, native_p_max, native_format, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            if (format_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_format);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool SliderScalar(string label, ImGuiDataType data_type, IntPtr p_data, IntPtr p_min, IntPtr p_max, string format, ImGuiSliderFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -14271,9 +25256,39 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderScalarN(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_min, IntPtr p_max)
-#else
-        public static bool SliderScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_min, IntPtr p_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            void* native_p_data = (void*)p_data.ToPointer();
+            void* native_p_min = (void*)p_min.ToPointer();
+            void* native_p_max = (void*)p_max.ToPointer();
+            byte* native_format = null;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            byte ret = ImGuiNative.igSliderScalarN(native_label, data_type, native_p_data, components, native_p_min, native_p_max, native_format, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool SliderScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_min, IntPtr p_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -14307,9 +25322,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderScalarN(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_min, IntPtr p_max, ReadOnlySpan<char> format)
-#else
-        public static bool SliderScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_min, IntPtr p_max, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            void* native_p_data = (void*)p_data.ToPointer();
+            void* native_p_min = (void*)p_min.ToPointer();
+            void* native_p_max = (void*)p_max.ToPointer();
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            byte ret = ImGuiNative.igSliderScalarN(native_label, data_type, native_p_data, components, native_p_min, native_p_max, native_format, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            if (format_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_format);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool SliderScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_min, IntPtr p_max, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -14364,9 +25430,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SliderScalarN(ReadOnlySpan<char> label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_min, IntPtr p_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool SliderScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_min, IntPtr p_max, string format, ImGuiSliderFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            void* native_p_data = (void*)p_data.ToPointer();
+            void* native_p_min = (void*)p_min.ToPointer();
+            void* native_p_max = (void*)p_max.ToPointer();
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            byte ret = ImGuiNative.igSliderScalarN(native_label, data_type, native_p_data, components, native_p_min, native_p_max, native_format, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            if (format_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_format);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool SliderScalarN(string label, ImGuiDataType data_type, IntPtr p_data, int components, IntPtr p_min, IntPtr p_max, string format, ImGuiSliderFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -14420,9 +25536,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool SmallButton(ReadOnlySpan<char> label)
-#else
-        public static bool SmallButton(string label)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte ret = ImGuiNative.igSmallButton(native_label);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool SmallButton(string label)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -14485,9 +25626,35 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool TabItemButton(ReadOnlySpan<char> label)
-#else
-        public static bool TabItemButton(string label)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            ImGuiTabItemFlags flags = (ImGuiTabItemFlags)0;
+            byte ret = ImGuiNative.igTabItemButton(native_label, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool TabItemButton(string label)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -14517,9 +25684,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool TabItemButton(ReadOnlySpan<char> label, ImGuiTabItemFlags flags)
-#else
-        public static bool TabItemButton(string label, ImGuiTabItemFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte ret = ImGuiNative.igTabItemButton(native_label, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool TabItemButton(string label, ImGuiTabItemFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -14590,9 +25782,33 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void TableHeader(ReadOnlySpan<char> label)
-#else
-        public static void TableHeader(string label)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            ImGuiNative.igTableHeader(native_label);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+        }
 #endif
+        public static void TableHeader(string label)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -14663,9 +25879,36 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void TableSetupColumn(ReadOnlySpan<char> label)
-#else
-        public static void TableSetupColumn(string label)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            ImGuiTableColumnFlags flags = (ImGuiTableColumnFlags)0;
+            float init_width_or_weight = 0.0f;
+            uint user_id = 0;
+            ImGuiNative.igTableSetupColumn(native_label, flags, init_width_or_weight, user_id);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+        }
 #endif
+        public static void TableSetupColumn(string label)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -14696,9 +25939,35 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void TableSetupColumn(ReadOnlySpan<char> label, ImGuiTableColumnFlags flags)
-#else
-        public static void TableSetupColumn(string label, ImGuiTableColumnFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            float init_width_or_weight = 0.0f;
+            uint user_id = 0;
+            ImGuiNative.igTableSetupColumn(native_label, flags, init_width_or_weight, user_id);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+        }
 #endif
+        public static void TableSetupColumn(string label, ImGuiTableColumnFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -14728,9 +25997,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void TableSetupColumn(ReadOnlySpan<char> label, ImGuiTableColumnFlags flags, float init_width_or_weight)
-#else
-        public static void TableSetupColumn(string label, ImGuiTableColumnFlags flags, float init_width_or_weight)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            uint user_id = 0;
+            ImGuiNative.igTableSetupColumn(native_label, flags, init_width_or_weight, user_id);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+        }
 #endif
+        public static void TableSetupColumn(string label, ImGuiTableColumnFlags flags, float init_width_or_weight)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -14759,9 +26053,33 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void TableSetupColumn(ReadOnlySpan<char> label, ImGuiTableColumnFlags flags, float init_width_or_weight, uint user_id)
-#else
-        public static void TableSetupColumn(string label, ImGuiTableColumnFlags flags, float init_width_or_weight, uint user_id)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            ImGuiNative.igTableSetupColumn(native_label, flags, init_width_or_weight, user_id);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+        }
 #endif
+        public static void TableSetupColumn(string label, ImGuiTableColumnFlags flags, float init_width_or_weight, uint user_id)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -14793,9 +26111,33 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void Text(ReadOnlySpan<char> fmt)
-#else
-        public static void Text(string fmt)
+        {
+            byte* native_fmt;
+            int fmt_byteCount = 0;
+            if (fmt != null)
+            {
+                fmt_byteCount = Encoding.UTF8.GetByteCount(fmt);
+                if (fmt_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_fmt = Util.Allocate(fmt_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_fmt_stackBytes = stackalloc byte[fmt_byteCount + 1];
+                    native_fmt = native_fmt_stackBytes;
+                }
+                int native_fmt_offset = Util.GetUtf8(fmt, native_fmt, fmt_byteCount);
+                native_fmt[native_fmt_offset] = 0;
+            }
+            else { native_fmt = null; }
+            ImGuiNative.igText(native_fmt);
+            if (fmt_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_fmt);
+            }
+        }
 #endif
+        public static void Text(string fmt)
         {
             byte* native_fmt;
             int fmt_byteCount = 0;
@@ -14823,9 +26165,33 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void TextColored(Vector4 col, ReadOnlySpan<char> fmt)
-#else
-        public static void TextColored(Vector4 col, string fmt)
+        {
+            byte* native_fmt;
+            int fmt_byteCount = 0;
+            if (fmt != null)
+            {
+                fmt_byteCount = Encoding.UTF8.GetByteCount(fmt);
+                if (fmt_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_fmt = Util.Allocate(fmt_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_fmt_stackBytes = stackalloc byte[fmt_byteCount + 1];
+                    native_fmt = native_fmt_stackBytes;
+                }
+                int native_fmt_offset = Util.GetUtf8(fmt, native_fmt, fmt_byteCount);
+                native_fmt[native_fmt_offset] = 0;
+            }
+            else { native_fmt = null; }
+            ImGuiNative.igTextColored(col, native_fmt);
+            if (fmt_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_fmt);
+            }
+        }
 #endif
+        public static void TextColored(Vector4 col, string fmt)
         {
             byte* native_fmt;
             int fmt_byteCount = 0;
@@ -14853,9 +26219,33 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void TextDisabled(ReadOnlySpan<char> fmt)
-#else
-        public static void TextDisabled(string fmt)
+        {
+            byte* native_fmt;
+            int fmt_byteCount = 0;
+            if (fmt != null)
+            {
+                fmt_byteCount = Encoding.UTF8.GetByteCount(fmt);
+                if (fmt_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_fmt = Util.Allocate(fmt_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_fmt_stackBytes = stackalloc byte[fmt_byteCount + 1];
+                    native_fmt = native_fmt_stackBytes;
+                }
+                int native_fmt_offset = Util.GetUtf8(fmt, native_fmt, fmt_byteCount);
+                native_fmt[native_fmt_offset] = 0;
+            }
+            else { native_fmt = null; }
+            ImGuiNative.igTextDisabled(native_fmt);
+            if (fmt_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_fmt);
+            }
+        }
 #endif
+        public static void TextDisabled(string fmt)
         {
             byte* native_fmt;
             int fmt_byteCount = 0;
@@ -14883,9 +26273,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void TextUnformatted(ReadOnlySpan<char> text)
-#else
-        public static void TextUnformatted(string text)
+        {
+            byte* native_text;
+            int text_byteCount = 0;
+            if (text != null)
+            {
+                text_byteCount = Encoding.UTF8.GetByteCount(text);
+                if (text_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_text = Util.Allocate(text_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_text_stackBytes = stackalloc byte[text_byteCount + 1];
+                    native_text = native_text_stackBytes;
+                }
+                int native_text_offset = Util.GetUtf8(text, native_text, text_byteCount);
+                native_text[native_text_offset] = 0;
+            }
+            else { native_text = null; }
+            byte* native_text_end = null;
+            ImGuiNative.igTextUnformatted(native_text, native_text_end);
+            if (text_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_text);
+            }
+        }
 #endif
+        public static void TextUnformatted(string text)
         {
             byte* native_text;
             int text_byteCount = 0;
@@ -14914,9 +26329,33 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void TextWrapped(ReadOnlySpan<char> fmt)
-#else
-        public static void TextWrapped(string fmt)
+        {
+            byte* native_fmt;
+            int fmt_byteCount = 0;
+            if (fmt != null)
+            {
+                fmt_byteCount = Encoding.UTF8.GetByteCount(fmt);
+                if (fmt_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_fmt = Util.Allocate(fmt_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_fmt_stackBytes = stackalloc byte[fmt_byteCount + 1];
+                    native_fmt = native_fmt_stackBytes;
+                }
+                int native_fmt_offset = Util.GetUtf8(fmt, native_fmt, fmt_byteCount);
+                native_fmt[native_fmt_offset] = 0;
+            }
+            else { native_fmt = null; }
+            ImGuiNative.igTextWrapped(native_fmt);
+            if (fmt_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_fmt);
+            }
+        }
 #endif
+        public static void TextWrapped(string fmt)
         {
             byte* native_fmt;
             int fmt_byteCount = 0;
@@ -14944,9 +26383,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool TreeNode(ReadOnlySpan<char> label)
-#else
-        public static bool TreeNode(string label)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte ret = ImGuiNative.igTreeNode_Str(native_label);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool TreeNode(string label)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -14975,9 +26439,56 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool TreeNode(ReadOnlySpan<char> str_id, ReadOnlySpan<char> fmt)
-#else
-        public static bool TreeNode(string str_id, string fmt)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            byte* native_fmt;
+            int fmt_byteCount = 0;
+            if (fmt != null)
+            {
+                fmt_byteCount = Encoding.UTF8.GetByteCount(fmt);
+                if (fmt_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_fmt = Util.Allocate(fmt_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_fmt_stackBytes = stackalloc byte[fmt_byteCount + 1];
+                    native_fmt = native_fmt_stackBytes;
+                }
+                int native_fmt_offset = Util.GetUtf8(fmt, native_fmt, fmt_byteCount);
+                native_fmt[native_fmt_offset] = 0;
+            }
+            else { native_fmt = null; }
+            byte ret = ImGuiNative.igTreeNode_StrStr(native_str_id, native_fmt);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+            if (fmt_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_fmt);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool TreeNode(string str_id, string fmt)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -15028,9 +26539,35 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool TreeNode(IntPtr ptr_id, ReadOnlySpan<char> fmt)
-#else
-        public static bool TreeNode(IntPtr ptr_id, string fmt)
+        {
+            void* native_ptr_id = (void*)ptr_id.ToPointer();
+            byte* native_fmt;
+            int fmt_byteCount = 0;
+            if (fmt != null)
+            {
+                fmt_byteCount = Encoding.UTF8.GetByteCount(fmt);
+                if (fmt_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_fmt = Util.Allocate(fmt_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_fmt_stackBytes = stackalloc byte[fmt_byteCount + 1];
+                    native_fmt = native_fmt_stackBytes;
+                }
+                int native_fmt_offset = Util.GetUtf8(fmt, native_fmt, fmt_byteCount);
+                native_fmt[native_fmt_offset] = 0;
+            }
+            else { native_fmt = null; }
+            byte ret = ImGuiNative.igTreeNode_Ptr(native_ptr_id, native_fmt);
+            if (fmt_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_fmt);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool TreeNode(IntPtr ptr_id, string fmt)
         {
             void* native_ptr_id = (void*)ptr_id.ToPointer();
             byte* native_fmt;
@@ -15060,9 +26597,35 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool TreeNodeEx(ReadOnlySpan<char> label)
-#else
-        public static bool TreeNodeEx(string label)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            ImGuiTreeNodeFlags flags = (ImGuiTreeNodeFlags)0;
+            byte ret = ImGuiNative.igTreeNodeEx_Str(native_label, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool TreeNodeEx(string label)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -15092,9 +26655,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool TreeNodeEx(ReadOnlySpan<char> label, ImGuiTreeNodeFlags flags)
-#else
-        public static bool TreeNodeEx(string label, ImGuiTreeNodeFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte ret = ImGuiNative.igTreeNodeEx_Str(native_label, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool TreeNodeEx(string label, ImGuiTreeNodeFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -15123,9 +26711,56 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool TreeNodeEx(ReadOnlySpan<char> str_id, ImGuiTreeNodeFlags flags, ReadOnlySpan<char> fmt)
-#else
-        public static bool TreeNodeEx(string str_id, ImGuiTreeNodeFlags flags, string fmt)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            byte* native_fmt;
+            int fmt_byteCount = 0;
+            if (fmt != null)
+            {
+                fmt_byteCount = Encoding.UTF8.GetByteCount(fmt);
+                if (fmt_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_fmt = Util.Allocate(fmt_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_fmt_stackBytes = stackalloc byte[fmt_byteCount + 1];
+                    native_fmt = native_fmt_stackBytes;
+                }
+                int native_fmt_offset = Util.GetUtf8(fmt, native_fmt, fmt_byteCount);
+                native_fmt[native_fmt_offset] = 0;
+            }
+            else { native_fmt = null; }
+            byte ret = ImGuiNative.igTreeNodeEx_StrStr(native_str_id, flags, native_fmt);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+            if (fmt_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_fmt);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool TreeNodeEx(string str_id, ImGuiTreeNodeFlags flags, string fmt)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -15176,9 +26811,35 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool TreeNodeEx(IntPtr ptr_id, ImGuiTreeNodeFlags flags, ReadOnlySpan<char> fmt)
-#else
-        public static bool TreeNodeEx(IntPtr ptr_id, ImGuiTreeNodeFlags flags, string fmt)
+        {
+            void* native_ptr_id = (void*)ptr_id.ToPointer();
+            byte* native_fmt;
+            int fmt_byteCount = 0;
+            if (fmt != null)
+            {
+                fmt_byteCount = Encoding.UTF8.GetByteCount(fmt);
+                if (fmt_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_fmt = Util.Allocate(fmt_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_fmt_stackBytes = stackalloc byte[fmt_byteCount + 1];
+                    native_fmt = native_fmt_stackBytes;
+                }
+                int native_fmt_offset = Util.GetUtf8(fmt, native_fmt, fmt_byteCount);
+                native_fmt[native_fmt_offset] = 0;
+            }
+            else { native_fmt = null; }
+            byte ret = ImGuiNative.igTreeNodeEx_Ptr(native_ptr_id, flags, native_fmt);
+            if (fmt_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_fmt);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool TreeNodeEx(IntPtr ptr_id, ImGuiTreeNodeFlags flags, string fmt)
         {
             void* native_ptr_id = (void*)ptr_id.ToPointer();
             byte* native_fmt;
@@ -15212,9 +26873,33 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void TreePush(ReadOnlySpan<char> str_id)
-#else
-        public static void TreePush(string str_id)
+        {
+            byte* native_str_id;
+            int str_id_byteCount = 0;
+            if (str_id != null)
+            {
+                str_id_byteCount = Encoding.UTF8.GetByteCount(str_id);
+                if (str_id_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str_id = Util.Allocate(str_id_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_id_stackBytes = stackalloc byte[str_id_byteCount + 1];
+                    native_str_id = native_str_id_stackBytes;
+                }
+                int native_str_id_offset = Util.GetUtf8(str_id, native_str_id, str_id_byteCount);
+                native_str_id[native_str_id_offset] = 0;
+            }
+            else { native_str_id = null; }
+            ImGuiNative.igTreePush_Str(native_str_id);
+            if (str_id_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str_id);
+            }
+        }
 #endif
+        public static void TreePush(string str_id)
         {
             byte* native_str_id;
             int str_id_byteCount = 0;
@@ -15260,9 +26945,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void Value(ReadOnlySpan<char> prefix, bool b)
-#else
-        public static void Value(string prefix, bool b)
+        {
+            byte* native_prefix;
+            int prefix_byteCount = 0;
+            if (prefix != null)
+            {
+                prefix_byteCount = Encoding.UTF8.GetByteCount(prefix);
+                if (prefix_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_prefix = Util.Allocate(prefix_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_prefix_stackBytes = stackalloc byte[prefix_byteCount + 1];
+                    native_prefix = native_prefix_stackBytes;
+                }
+                int native_prefix_offset = Util.GetUtf8(prefix, native_prefix, prefix_byteCount);
+                native_prefix[native_prefix_offset] = 0;
+            }
+            else { native_prefix = null; }
+            byte native_b = b ? (byte)1 : (byte)0;
+            ImGuiNative.igValue_Bool(native_prefix, native_b);
+            if (prefix_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_prefix);
+            }
+        }
 #endif
+        public static void Value(string prefix, bool b)
         {
             byte* native_prefix;
             int prefix_byteCount = 0;
@@ -15291,9 +27001,33 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void Value(ReadOnlySpan<char> prefix, int v)
-#else
-        public static void Value(string prefix, int v)
+        {
+            byte* native_prefix;
+            int prefix_byteCount = 0;
+            if (prefix != null)
+            {
+                prefix_byteCount = Encoding.UTF8.GetByteCount(prefix);
+                if (prefix_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_prefix = Util.Allocate(prefix_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_prefix_stackBytes = stackalloc byte[prefix_byteCount + 1];
+                    native_prefix = native_prefix_stackBytes;
+                }
+                int native_prefix_offset = Util.GetUtf8(prefix, native_prefix, prefix_byteCount);
+                native_prefix[native_prefix_offset] = 0;
+            }
+            else { native_prefix = null; }
+            ImGuiNative.igValue_Int(native_prefix, v);
+            if (prefix_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_prefix);
+            }
+        }
 #endif
+        public static void Value(string prefix, int v)
         {
             byte* native_prefix;
             int prefix_byteCount = 0;
@@ -15321,9 +27055,33 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void Value(ReadOnlySpan<char> prefix, uint v)
-#else
-        public static void Value(string prefix, uint v)
+        {
+            byte* native_prefix;
+            int prefix_byteCount = 0;
+            if (prefix != null)
+            {
+                prefix_byteCount = Encoding.UTF8.GetByteCount(prefix);
+                if (prefix_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_prefix = Util.Allocate(prefix_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_prefix_stackBytes = stackalloc byte[prefix_byteCount + 1];
+                    native_prefix = native_prefix_stackBytes;
+                }
+                int native_prefix_offset = Util.GetUtf8(prefix, native_prefix, prefix_byteCount);
+                native_prefix[native_prefix_offset] = 0;
+            }
+            else { native_prefix = null; }
+            ImGuiNative.igValue_Uint(native_prefix, v);
+            if (prefix_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_prefix);
+            }
+        }
 #endif
+        public static void Value(string prefix, uint v)
         {
             byte* native_prefix;
             int prefix_byteCount = 0;
@@ -15351,9 +27109,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void Value(ReadOnlySpan<char> prefix, float v)
-#else
-        public static void Value(string prefix, float v)
+        {
+            byte* native_prefix;
+            int prefix_byteCount = 0;
+            if (prefix != null)
+            {
+                prefix_byteCount = Encoding.UTF8.GetByteCount(prefix);
+                if (prefix_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_prefix = Util.Allocate(prefix_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_prefix_stackBytes = stackalloc byte[prefix_byteCount + 1];
+                    native_prefix = native_prefix_stackBytes;
+                }
+                int native_prefix_offset = Util.GetUtf8(prefix, native_prefix, prefix_byteCount);
+                native_prefix[native_prefix_offset] = 0;
+            }
+            else { native_prefix = null; }
+            byte* native_float_format = null;
+            ImGuiNative.igValue_Float(native_prefix, v, native_float_format);
+            if (prefix_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_prefix);
+            }
+        }
 #endif
+        public static void Value(string prefix, float v)
         {
             byte* native_prefix;
             int prefix_byteCount = 0;
@@ -15382,9 +27165,55 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static void Value(ReadOnlySpan<char> prefix, float v, ReadOnlySpan<char> float_format)
-#else
-        public static void Value(string prefix, float v, string float_format)
+        {
+            byte* native_prefix;
+            int prefix_byteCount = 0;
+            if (prefix != null)
+            {
+                prefix_byteCount = Encoding.UTF8.GetByteCount(prefix);
+                if (prefix_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_prefix = Util.Allocate(prefix_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_prefix_stackBytes = stackalloc byte[prefix_byteCount + 1];
+                    native_prefix = native_prefix_stackBytes;
+                }
+                int native_prefix_offset = Util.GetUtf8(prefix, native_prefix, prefix_byteCount);
+                native_prefix[native_prefix_offset] = 0;
+            }
+            else { native_prefix = null; }
+            byte* native_float_format;
+            int float_format_byteCount = 0;
+            if (float_format != null)
+            {
+                float_format_byteCount = Encoding.UTF8.GetByteCount(float_format);
+                if (float_format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_float_format = Util.Allocate(float_format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_float_format_stackBytes = stackalloc byte[float_format_byteCount + 1];
+                    native_float_format = native_float_format_stackBytes;
+                }
+                int native_float_format_offset = Util.GetUtf8(float_format, native_float_format, float_format_byteCount);
+                native_float_format[native_float_format_offset] = 0;
+            }
+            else { native_float_format = null; }
+            ImGuiNative.igValue_Float(native_prefix, v, native_float_format);
+            if (prefix_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_prefix);
+            }
+            if (float_format_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_float_format);
+            }
+        }
 #endif
+        public static void Value(string prefix, float v, string float_format)
         {
             byte* native_prefix;
             int prefix_byteCount = 0;
@@ -15434,9 +27263,56 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool VSliderFloat(ReadOnlySpan<char> label, Vector2 size, ref float v, float v_min, float v_max)
-#else
-        public static bool VSliderFloat(string label, Vector2 size, ref float v, float v_min, float v_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%.3f");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%.3f", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (float* native_v = &v)
+            {
+                byte ret = ImGuiNative.igVSliderFloat(native_label, size, native_v, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool VSliderFloat(string label, Vector2 size, ref float v, float v_min, float v_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -15487,9 +27363,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool VSliderFloat(ReadOnlySpan<char> label, Vector2 size, ref float v, float v_min, float v_max, ReadOnlySpan<char> format)
-#else
-        public static bool VSliderFloat(string label, Vector2 size, ref float v, float v_min, float v_max, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (float* native_v = &v)
+            {
+                byte ret = ImGuiNative.igVSliderFloat(native_label, size, native_v, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool VSliderFloat(string label, Vector2 size, ref float v, float v_min, float v_max, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -15544,9 +27471,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool VSliderFloat(ReadOnlySpan<char> label, Vector2 size, ref float v, float v_min, float v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool VSliderFloat(string label, Vector2 size, ref float v, float v_min, float v_max, string format, ImGuiSliderFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            fixed (float* native_v = &v)
+            {
+                byte ret = ImGuiNative.igVSliderFloat(native_label, size, native_v, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool VSliderFloat(string label, Vector2 size, ref float v, float v_min, float v_max, string format, ImGuiSliderFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -15600,9 +27577,56 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool VSliderInt(ReadOnlySpan<char> label, Vector2 size, ref int v, int v_min, int v_max)
-#else
-        public static bool VSliderInt(string label, Vector2 size, ref int v, int v_min, int v_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+                format_byteCount = Encoding.UTF8.GetByteCount("%d");
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8("%d", native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igVSliderInt(native_label, size, native_v, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool VSliderInt(string label, Vector2 size, ref int v, int v_min, int v_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -15653,9 +27677,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool VSliderInt(ReadOnlySpan<char> label, Vector2 size, ref int v, int v_min, int v_max, ReadOnlySpan<char> format)
-#else
-        public static bool VSliderInt(string label, Vector2 size, ref int v, int v_min, int v_max, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igVSliderInt(native_label, size, native_v, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool VSliderInt(string label, Vector2 size, ref int v, int v_min, int v_max, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -15710,9 +27785,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool VSliderInt(ReadOnlySpan<char> label, Vector2 size, ref int v, int v_min, int v_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool VSliderInt(string label, Vector2 size, ref int v, int v_min, int v_max, string format, ImGuiSliderFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            fixed (int* native_v = &v)
+            {
+                byte ret = ImGuiNative.igVSliderInt(native_label, size, native_v, v_min, v_max, native_format, flags);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_label);
+                }
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    Util.Free(native_format);
+                }
+                return ret != 0;
+            }
+        }
 #endif
+        public static bool VSliderInt(string label, Vector2 size, ref int v, int v_min, int v_max, string format, ImGuiSliderFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -15766,9 +27891,39 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool VSliderScalar(ReadOnlySpan<char> label, Vector2 size, ImGuiDataType data_type, IntPtr p_data, IntPtr p_min, IntPtr p_max)
-#else
-        public static bool VSliderScalar(string label, Vector2 size, ImGuiDataType data_type, IntPtr p_data, IntPtr p_min, IntPtr p_max)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            void* native_p_data = (void*)p_data.ToPointer();
+            void* native_p_min = (void*)p_min.ToPointer();
+            void* native_p_max = (void*)p_max.ToPointer();
+            byte* native_format = null;
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            byte ret = ImGuiNative.igVSliderScalar(native_label, size, data_type, native_p_data, native_p_min, native_p_max, native_format, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool VSliderScalar(string label, Vector2 size, ImGuiDataType data_type, IntPtr p_data, IntPtr p_min, IntPtr p_max)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -15802,9 +27957,60 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool VSliderScalar(ReadOnlySpan<char> label, Vector2 size, ImGuiDataType data_type, IntPtr p_data, IntPtr p_min, IntPtr p_max, ReadOnlySpan<char> format)
-#else
-        public static bool VSliderScalar(string label, Vector2 size, ImGuiDataType data_type, IntPtr p_data, IntPtr p_min, IntPtr p_max, string format)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            void* native_p_data = (void*)p_data.ToPointer();
+            void* native_p_min = (void*)p_min.ToPointer();
+            void* native_p_max = (void*)p_max.ToPointer();
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            ImGuiSliderFlags flags = (ImGuiSliderFlags)0;
+            byte ret = ImGuiNative.igVSliderScalar(native_label, size, data_type, native_p_data, native_p_min, native_p_max, native_format, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            if (format_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_format);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool VSliderScalar(string label, Vector2 size, ImGuiDataType data_type, IntPtr p_data, IntPtr p_min, IntPtr p_max, string format)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -15859,9 +28065,59 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public static bool VSliderScalar(ReadOnlySpan<char> label, Vector2 size, ImGuiDataType data_type, IntPtr p_data, IntPtr p_min, IntPtr p_max, ReadOnlySpan<char> format, ImGuiSliderFlags flags)
-#else
-        public static bool VSliderScalar(string label, Vector2 size, ImGuiDataType data_type, IntPtr p_data, IntPtr p_min, IntPtr p_max, string format, ImGuiSliderFlags flags)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            void* native_p_data = (void*)p_data.ToPointer();
+            void* native_p_min = (void*)p_min.ToPointer();
+            void* native_p_max = (void*)p_max.ToPointer();
+            byte* native_format;
+            int format_byteCount = 0;
+            if (format != null)
+            {
+                format_byteCount = Encoding.UTF8.GetByteCount(format);
+                if (format_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_format = Util.Allocate(format_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_format_stackBytes = stackalloc byte[format_byteCount + 1];
+                    native_format = native_format_stackBytes;
+                }
+                int native_format_offset = Util.GetUtf8(format, native_format, format_byteCount);
+                native_format[native_format_offset] = 0;
+            }
+            else { native_format = null; }
+            byte ret = ImGuiNative.igVSliderScalar(native_label, size, data_type, native_p_data, native_p_min, native_p_max, native_format, flags);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            if (format_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_format);
+            }
+            return ret != 0;
+        }
 #endif
+        public static bool VSliderScalar(string label, Vector2 size, ImGuiDataType data_type, IntPtr p_data, IntPtr p_min, IntPtr p_max, string format, ImGuiSliderFlags flags)
         {
             byte* native_label;
             int label_byteCount = 0;

--- a/src/ImGui.NET/Generated/ImGuiIO.gen.cs
+++ b/src/ImGui.NET/Generated/ImGuiIO.gen.cs
@@ -892,9 +892,33 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public void AddInputCharactersUTF8(ReadOnlySpan<char> str)
-#else
-        public void AddInputCharactersUTF8(string str)
+        {
+            byte* native_str;
+            int str_byteCount = 0;
+            if (str != null)
+            {
+                str_byteCount = Encoding.UTF8.GetByteCount(str);
+                if (str_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str = Util.Allocate(str_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_stackBytes = stackalloc byte[str_byteCount + 1];
+                    native_str = native_str_stackBytes;
+                }
+                int native_str_offset = Util.GetUtf8(str, native_str, str_byteCount);
+                native_str[native_str_offset] = 0;
+            }
+            else { native_str = null; }
+            ImGuiNative.ImGuiIO_AddInputCharactersUTF8((ImGuiIO*)(NativePtr), native_str);
+            if (str_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str);
+            }
+        }
 #endif
+        public void AddInputCharactersUTF8(string str)
         {
             byte* native_str;
             int str_byteCount = 0;

--- a/src/ImGui.NET/Generated/ImGuiPayload.gen.cs
+++ b/src/ImGui.NET/Generated/ImGuiPayload.gen.cs
@@ -42,9 +42,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public bool IsDataType(ReadOnlySpan<char> type)
-#else
-        public bool IsDataType(string type)
+        {
+            byte* native_type;
+            int type_byteCount = 0;
+            if (type != null)
+            {
+                type_byteCount = Encoding.UTF8.GetByteCount(type);
+                if (type_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_type = Util.Allocate(type_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_type_stackBytes = stackalloc byte[type_byteCount + 1];
+                    native_type = native_type_stackBytes;
+                }
+                int native_type_offset = Util.GetUtf8(type, native_type, type_byteCount);
+                native_type[native_type_offset] = 0;
+            }
+            else { native_type = null; }
+            byte ret = ImGuiNative.ImGuiPayload_IsDataType((ImGuiPayload*)(NativePtr), native_type);
+            if (type_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_type);
+            }
+            return ret != 0;
+        }
 #endif
+        public bool IsDataType(string type)
         {
             byte* native_type;
             int type_byteCount = 0;

--- a/src/ImGui.NET/Generated/ImGuiTextBuffer.gen.cs
+++ b/src/ImGui.NET/Generated/ImGuiTextBuffer.gen.cs
@@ -20,9 +20,34 @@ namespace ImGuiNET
         public ImVector<byte> Buf => new ImVector<byte>(NativePtr->Buf);
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public void append(ReadOnlySpan<char> str)
-#else
-        public void append(string str)
+        {
+            byte* native_str;
+            int str_byteCount = 0;
+            if (str != null)
+            {
+                str_byteCount = Encoding.UTF8.GetByteCount(str);
+                if (str_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_str = Util.Allocate(str_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_str_stackBytes = stackalloc byte[str_byteCount + 1];
+                    native_str = native_str_stackBytes;
+                }
+                int native_str_offset = Util.GetUtf8(str, native_str, str_byteCount);
+                native_str[native_str_offset] = 0;
+            }
+            else { native_str = null; }
+            byte* native_str_end = null;
+            ImGuiNative.ImGuiTextBuffer_append((ImGuiTextBuffer*)(NativePtr), native_str, native_str_end);
+            if (str_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_str);
+            }
+        }
 #endif
+        public void append(string str)
         {
             byte* native_str;
             int str_byteCount = 0;
@@ -51,9 +76,33 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public void appendf(ReadOnlySpan<char> fmt)
-#else
-        public void appendf(string fmt)
+        {
+            byte* native_fmt;
+            int fmt_byteCount = 0;
+            if (fmt != null)
+            {
+                fmt_byteCount = Encoding.UTF8.GetByteCount(fmt);
+                if (fmt_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_fmt = Util.Allocate(fmt_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_fmt_stackBytes = stackalloc byte[fmt_byteCount + 1];
+                    native_fmt = native_fmt_stackBytes;
+                }
+                int native_fmt_offset = Util.GetUtf8(fmt, native_fmt, fmt_byteCount);
+                native_fmt[native_fmt_offset] = 0;
+            }
+            else { native_fmt = null; }
+            ImGuiNative.ImGuiTextBuffer_appendf((ImGuiTextBuffer*)(NativePtr), native_fmt);
+            if (fmt_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_fmt);
+            }
+        }
 #endif
+        public void appendf(string fmt)
         {
             byte* native_fmt;
             int fmt_byteCount = 0;

--- a/src/ImGui.NET/Generated/ImGuiTextFilter.gen.cs
+++ b/src/ImGui.NET/Generated/ImGuiTextFilter.gen.cs
@@ -60,9 +60,35 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public bool Draw(ReadOnlySpan<char> label)
-#else
-        public bool Draw(string label)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            float width = 0.0f;
+            byte ret = ImGuiNative.ImGuiTextFilter_Draw((ImGuiTextFilter*)(NativePtr), native_label, width);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public bool Draw(string label)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -92,9 +118,34 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public bool Draw(ReadOnlySpan<char> label, float width)
-#else
-        public bool Draw(string label, float width)
+        {
+            byte* native_label;
+            int label_byteCount = 0;
+            if (label != null)
+            {
+                label_byteCount = Encoding.UTF8.GetByteCount(label);
+                if (label_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_label = Util.Allocate(label_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+                    native_label = native_label_stackBytes;
+                }
+                int native_label_offset = Util.GetUtf8(label, native_label, label_byteCount);
+                native_label[native_label_offset] = 0;
+            }
+            else { native_label = null; }
+            byte ret = ImGuiNative.ImGuiTextFilter_Draw((ImGuiTextFilter*)(NativePtr), native_label, width);
+            if (label_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_label);
+            }
+            return ret != 0;
+        }
 #endif
+        public bool Draw(string label, float width)
         {
             byte* native_label;
             int label_byteCount = 0;
@@ -128,9 +179,35 @@ namespace ImGuiNET
         }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
         public bool PassFilter(ReadOnlySpan<char> text)
-#else
-        public bool PassFilter(string text)
+        {
+            byte* native_text;
+            int text_byteCount = 0;
+            if (text != null)
+            {
+                text_byteCount = Encoding.UTF8.GetByteCount(text);
+                if (text_byteCount > Util.StackAllocationSizeLimit)
+                {
+                    native_text = Util.Allocate(text_byteCount + 1);
+                }
+                else
+                {
+                    byte* native_text_stackBytes = stackalloc byte[text_byteCount + 1];
+                    native_text = native_text_stackBytes;
+                }
+                int native_text_offset = Util.GetUtf8(text, native_text, text_byteCount);
+                native_text[native_text_offset] = 0;
+            }
+            else { native_text = null; }
+            byte* native_text_end = null;
+            byte ret = ImGuiNative.ImGuiTextFilter_PassFilter((ImGuiTextFilter*)(NativePtr), native_text, native_text_end);
+            if (text_byteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(native_text);
+            }
+            return ret != 0;
+        }
 #endif
+        public bool PassFilter(string text)
         {
             byte* native_text;
             int text_byteCount = 0;

--- a/src/ImGui.NET/ImGui.Manual.ReadOnlySpan.cs
+++ b/src/ImGui.NET/ImGui.Manual.ReadOnlySpan.cs
@@ -1,0 +1,524 @@
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+// NOTE:
+// This is a direct copy from ImGui.Manual.cs with all string parameters (not ref string) changed to ReadOnlySpan<char>.
+// This is far from ideal right now, maybe we could update the generator to do this for us.
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+namespace ImGuiNET
+{
+    public static unsafe partial class ImGui
+    {
+        public static bool InputText(
+            ReadOnlySpan<char> label,
+            byte[] buf,
+            uint buf_size)
+        {
+            return InputText(label, buf, buf_size, 0, null, IntPtr.Zero);
+        }
+
+        public static bool InputText(
+            ReadOnlySpan<char> label,
+            byte[] buf,
+            uint buf_size,
+            ImGuiInputTextFlags flags)
+        {
+            return InputText(label, buf, buf_size, flags, null, IntPtr.Zero);
+        }
+
+        public static bool InputText(
+            ReadOnlySpan<char> label,
+            byte[] buf,
+            uint buf_size,
+            ImGuiInputTextFlags flags,
+            ImGuiInputTextCallback callback)
+        {
+            return InputText(label, buf, buf_size, flags, callback, IntPtr.Zero);
+        }
+
+        public static bool InputText(
+            ReadOnlySpan<char> label,
+            byte[] buf,
+            uint buf_size,
+            ImGuiInputTextFlags flags,
+            ImGuiInputTextCallback callback,
+            IntPtr user_data)
+        {
+            int utf8LabelByteCount = Encoding.UTF8.GetByteCount(label);
+            byte* utf8LabelBytes;
+            if (utf8LabelByteCount > Util.StackAllocationSizeLimit)
+            {
+                utf8LabelBytes = Util.Allocate(utf8LabelByteCount + 1);
+            }
+            else
+            {
+                byte* stackPtr = stackalloc byte[utf8LabelByteCount + 1];
+                utf8LabelBytes = stackPtr;
+            }
+            Util.GetUtf8(label, utf8LabelBytes, utf8LabelByteCount);
+
+            bool ret;
+            fixed (byte* bufPtr = buf)
+            {
+                ret = ImGuiNative.igInputText(utf8LabelBytes, bufPtr, buf_size, flags, callback, user_data.ToPointer()) != 0;
+            }
+
+            if (utf8LabelByteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(utf8LabelBytes);
+            }
+
+            return ret;
+        }
+
+        public static bool InputText(
+            ReadOnlySpan<char> label,
+            ref string input,
+            uint maxLength) => InputText(label, ref input, maxLength, 0, null, IntPtr.Zero);
+
+        public static bool InputText(
+            ReadOnlySpan<char> label,
+            ref string input,
+            uint maxLength,
+            ImGuiInputTextFlags flags) => InputText(label, ref input, maxLength, flags, null, IntPtr.Zero);
+
+        public static bool InputText(
+            ReadOnlySpan<char> label,
+            ref string input,
+            uint maxLength,
+            ImGuiInputTextFlags flags,
+            ImGuiInputTextCallback callback) => InputText(label, ref input, maxLength, flags, callback, IntPtr.Zero);
+
+        public static bool InputText(
+            ReadOnlySpan<char> label,
+            ref string input,
+            uint maxLength,
+            ImGuiInputTextFlags flags,
+            ImGuiInputTextCallback callback,
+            IntPtr user_data)
+        {
+            int utf8LabelByteCount = Encoding.UTF8.GetByteCount(label);
+            byte* utf8LabelBytes;
+            if (utf8LabelByteCount > Util.StackAllocationSizeLimit)
+            {
+                utf8LabelBytes = Util.Allocate(utf8LabelByteCount + 1);
+            }
+            else
+            {
+                byte* stackPtr = stackalloc byte[utf8LabelByteCount + 1];
+                utf8LabelBytes = stackPtr;
+            }
+            Util.GetUtf8(label, utf8LabelBytes, utf8LabelByteCount);
+
+            int utf8InputByteCount = Encoding.UTF8.GetByteCount(input);
+            int inputBufSize = Math.Max((int)maxLength + 1, utf8InputByteCount + 1);
+
+            byte* utf8InputBytes;
+            byte* originalUtf8InputBytes;
+            if (inputBufSize > Util.StackAllocationSizeLimit)
+            {
+                utf8InputBytes = Util.Allocate(inputBufSize);
+                originalUtf8InputBytes = Util.Allocate(inputBufSize);
+            }
+            else
+            {
+                byte* inputStackBytes = stackalloc byte[inputBufSize];
+                utf8InputBytes = inputStackBytes;
+                byte* originalInputStackBytes = stackalloc byte[inputBufSize];
+                originalUtf8InputBytes = originalInputStackBytes;
+            }
+            Util.GetUtf8(input, utf8InputBytes, inputBufSize);
+            uint clearBytesCount = (uint)(inputBufSize - utf8InputByteCount);
+            Unsafe.InitBlockUnaligned(utf8InputBytes + utf8InputByteCount, 0, clearBytesCount);
+            Unsafe.CopyBlock(originalUtf8InputBytes, utf8InputBytes, (uint)inputBufSize);
+
+            byte result = ImGuiNative.igInputText(
+                utf8LabelBytes,
+                utf8InputBytes,
+                (uint)inputBufSize,
+                flags,
+                callback,
+                user_data.ToPointer());
+            if (!Util.AreStringsEqual(originalUtf8InputBytes, inputBufSize, utf8InputBytes))
+            {
+                input = Util.StringFromPtr(utf8InputBytes);
+            }
+
+            if (utf8LabelByteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(utf8LabelBytes);
+            }
+            if (inputBufSize > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(utf8InputBytes);
+                Util.Free(originalUtf8InputBytes);
+            }
+
+            return result != 0;
+        }
+
+        public static bool InputTextMultiline(
+            ReadOnlySpan<char> label,
+            ref string input,
+            uint maxLength,
+            Vector2 size) => InputTextMultiline(label, ref input, maxLength, size, 0, null, IntPtr.Zero);
+
+        public static bool InputTextMultiline(
+            ReadOnlySpan<char> label,
+            ref string input,
+            uint maxLength,
+            Vector2 size,
+            ImGuiInputTextFlags flags) => InputTextMultiline(label, ref input, maxLength, size, flags, null, IntPtr.Zero);
+
+        public static bool InputTextMultiline(
+            ReadOnlySpan<char> label,
+            ref string input,
+            uint maxLength,
+            Vector2 size,
+            ImGuiInputTextFlags flags,
+            ImGuiInputTextCallback callback) => InputTextMultiline(label, ref input, maxLength, size, flags, callback, IntPtr.Zero);
+
+        public static bool InputTextMultiline(
+            ReadOnlySpan<char> label,
+            ref string input,
+            uint maxLength,
+            Vector2 size,
+            ImGuiInputTextFlags flags,
+            ImGuiInputTextCallback callback,
+            IntPtr user_data)
+        {
+            int utf8LabelByteCount = Encoding.UTF8.GetByteCount(label);
+            byte* utf8LabelBytes;
+            if (utf8LabelByteCount > Util.StackAllocationSizeLimit)
+            {
+                utf8LabelBytes = Util.Allocate(utf8LabelByteCount + 1);
+            }
+            else
+            {
+                byte* stackPtr = stackalloc byte[utf8LabelByteCount + 1];
+                utf8LabelBytes = stackPtr;
+            }
+            Util.GetUtf8(label, utf8LabelBytes, utf8LabelByteCount);
+
+            int utf8InputByteCount = Encoding.UTF8.GetByteCount(input);
+            int inputBufSize = Math.Max((int)maxLength + 1, utf8InputByteCount + 1);
+
+            byte* utf8InputBytes;
+            byte* originalUtf8InputBytes;
+            if (inputBufSize > Util.StackAllocationSizeLimit)
+            {
+                utf8InputBytes = Util.Allocate(inputBufSize);
+                originalUtf8InputBytes = Util.Allocate(inputBufSize);
+            }
+            else
+            {
+                byte* inputStackBytes = stackalloc byte[inputBufSize];
+                utf8InputBytes = inputStackBytes;
+                byte* originalInputStackBytes = stackalloc byte[inputBufSize];
+                originalUtf8InputBytes = originalInputStackBytes;
+            }
+            Util.GetUtf8(input, utf8InputBytes, inputBufSize);
+            uint clearBytesCount = (uint)(inputBufSize - utf8InputByteCount);
+            Unsafe.InitBlockUnaligned(utf8InputBytes + utf8InputByteCount, 0, clearBytesCount);
+            Unsafe.CopyBlock(originalUtf8InputBytes, utf8InputBytes, (uint)inputBufSize);
+
+            byte result = ImGuiNative.igInputTextMultiline(
+                utf8LabelBytes,
+                utf8InputBytes,
+                (uint)inputBufSize,
+                size,
+                flags,
+                callback,
+                user_data.ToPointer());
+            if (!Util.AreStringsEqual(originalUtf8InputBytes, inputBufSize, utf8InputBytes))
+            {
+                input = Util.StringFromPtr(utf8InputBytes);
+            }
+
+            if (utf8LabelByteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(utf8LabelBytes);
+            }
+            if (inputBufSize > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(utf8InputBytes);
+                Util.Free(originalUtf8InputBytes);
+            }
+
+            return result != 0;
+        }
+
+        public static bool InputTextWithHint(
+            ReadOnlySpan<char> label,
+            ReadOnlySpan<char> hint,
+            ref string input,
+            uint maxLength) => InputTextWithHint(label, hint, ref input, maxLength, 0, null, IntPtr.Zero);
+
+        public static bool InputTextWithHint(
+            ReadOnlySpan<char> label,
+            ReadOnlySpan<char> hint,
+            ref string input,
+            uint maxLength,
+            ImGuiInputTextFlags flags) => InputTextWithHint(label, hint, ref input, maxLength, flags, null, IntPtr.Zero);
+
+        public static bool InputTextWithHint(
+            ReadOnlySpan<char> label,
+            ReadOnlySpan<char> hint,
+            ref string input,
+            uint maxLength,
+            ImGuiInputTextFlags flags,
+            ImGuiInputTextCallback callback) => InputTextWithHint(label, hint, ref input, maxLength, flags, callback, IntPtr.Zero);
+
+        public static bool InputTextWithHint(
+            ReadOnlySpan<char> label,
+            ReadOnlySpan<char> hint,
+            ref string input,
+            uint maxLength,
+            ImGuiInputTextFlags flags,
+            ImGuiInputTextCallback callback,
+            IntPtr user_data)
+        {
+            int utf8LabelByteCount = Encoding.UTF8.GetByteCount(label);
+            byte* utf8LabelBytes;
+            if (utf8LabelByteCount > Util.StackAllocationSizeLimit)
+            {
+                utf8LabelBytes = Util.Allocate(utf8LabelByteCount + 1);
+            }
+            else
+            {
+                byte* stackPtr = stackalloc byte[utf8LabelByteCount + 1];
+                utf8LabelBytes = stackPtr;
+            }
+            Util.GetUtf8(label, utf8LabelBytes, utf8LabelByteCount);
+
+            int utf8HintByteCount = Encoding.UTF8.GetByteCount(hint);
+            byte* utf8HintBytes;
+            if (utf8HintByteCount > Util.StackAllocationSizeLimit)
+            {
+                utf8HintBytes = Util.Allocate(utf8HintByteCount + 1);
+            }
+            else
+            {
+                byte* stackPtr = stackalloc byte[utf8HintByteCount + 1];
+                utf8HintBytes = stackPtr;
+            }
+            Util.GetUtf8(hint, utf8HintBytes, utf8HintByteCount);
+
+            int utf8InputByteCount = Encoding.UTF8.GetByteCount(input);
+            int inputBufSize = Math.Max((int)maxLength + 1, utf8InputByteCount + 1);
+
+            byte* utf8InputBytes;
+            byte* originalUtf8InputBytes;
+            if (inputBufSize > Util.StackAllocationSizeLimit)
+            {
+                utf8InputBytes = Util.Allocate(inputBufSize);
+                originalUtf8InputBytes = Util.Allocate(inputBufSize);
+            }
+            else
+            {
+                byte* inputStackBytes = stackalloc byte[inputBufSize];
+                utf8InputBytes = inputStackBytes;
+                byte* originalInputStackBytes = stackalloc byte[inputBufSize];
+                originalUtf8InputBytes = originalInputStackBytes;
+            }
+            Util.GetUtf8(input, utf8InputBytes, inputBufSize);
+            uint clearBytesCount = (uint)(inputBufSize - utf8InputByteCount);
+            Unsafe.InitBlockUnaligned(utf8InputBytes + utf8InputByteCount, 0, clearBytesCount);
+            Unsafe.CopyBlock(originalUtf8InputBytes, utf8InputBytes, (uint)inputBufSize);
+
+            byte result = ImGuiNative.igInputTextWithHint(
+                utf8LabelBytes,
+                utf8HintBytes,
+                utf8InputBytes,
+                (uint)inputBufSize,
+                flags,
+                callback,
+                user_data.ToPointer());
+            if (!Util.AreStringsEqual(originalUtf8InputBytes, inputBufSize, utf8InputBytes))
+            {
+                input = Util.StringFromPtr(utf8InputBytes);
+            }
+
+            if (utf8LabelByteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(utf8LabelBytes);
+            }
+            if (utf8HintByteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(utf8HintBytes);
+            }
+            if (inputBufSize > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(utf8InputBytes);
+                Util.Free(originalUtf8InputBytes);
+            }
+
+            return result != 0;
+        }
+
+        public static Vector2 CalcTextSize(ReadOnlySpan<char> text)
+            => CalcTextSizeImpl(text);
+
+        public static Vector2 CalcTextSize(ReadOnlySpan<char> text, int start)
+            => CalcTextSizeImpl(text, start);
+
+        public static Vector2 CalcTextSize(ReadOnlySpan<char> text, float wrapWidth)
+            => CalcTextSizeImpl(text, wrapWidth: wrapWidth);
+
+        public static Vector2 CalcTextSize(ReadOnlySpan<char> text, bool hideTextAfterDoubleHash)
+            => CalcTextSizeImpl(text, hideTextAfterDoubleHash: hideTextAfterDoubleHash);
+
+        public static Vector2 CalcTextSize(ReadOnlySpan<char> text, int start, int length)
+            => CalcTextSizeImpl(text, start, length);
+
+        public static Vector2 CalcTextSize(ReadOnlySpan<char> text, int start, bool hideTextAfterDoubleHash)
+            => CalcTextSizeImpl(text, start, hideTextAfterDoubleHash: hideTextAfterDoubleHash);
+
+        public static Vector2 CalcTextSize(ReadOnlySpan<char> text, int start, float wrapWidth)
+            => CalcTextSizeImpl(text, start, wrapWidth: wrapWidth);
+
+        public static Vector2 CalcTextSize(ReadOnlySpan<char> text, bool hideTextAfterDoubleHash, float wrapWidth)
+            => CalcTextSizeImpl(text, hideTextAfterDoubleHash: hideTextAfterDoubleHash, wrapWidth: wrapWidth);
+
+        public static Vector2 CalcTextSize(ReadOnlySpan<char> text, int start, int length, bool hideTextAfterDoubleHash)
+            => CalcTextSizeImpl(text, start, length, hideTextAfterDoubleHash);
+
+        public static Vector2 CalcTextSize(ReadOnlySpan<char> text, int start, int length, float wrapWidth)
+            => CalcTextSizeImpl(text, start, length, wrapWidth: wrapWidth);
+
+        public static Vector2 CalcTextSize(ReadOnlySpan<char> text, int start, int length, bool hideTextAfterDoubleHash, float wrapWidth)
+            => CalcTextSizeImpl(text, start, length, hideTextAfterDoubleHash, wrapWidth);
+
+        private static Vector2 CalcTextSizeImpl(
+            ReadOnlySpan<char> text,
+            int start = 0,
+            int? length = null,
+            bool hideTextAfterDoubleHash = false,
+            float wrapWidth = -1.0f)
+        {
+            Vector2 ret;
+            byte* nativeTextStart = null;
+            byte* nativeTextEnd = null;
+            int textByteCount = 0;
+            if (text != null)
+            {
+
+                int textToCopyLen = length.HasValue ? length.Value : text.Length;
+                textByteCount = Util.CalcSizeInUtf8(text, start, textToCopyLen);
+                if (textByteCount > Util.StackAllocationSizeLimit)
+                {
+                    nativeTextStart = Util.Allocate(textByteCount + 1);
+                }
+                else
+                {
+                    byte* nativeTextStackBytes = stackalloc byte[textByteCount + 1];
+                    nativeTextStart = nativeTextStackBytes;
+                }
+
+                int nativeTextOffset = Util.GetUtf8(text, start, textToCopyLen, nativeTextStart, textByteCount);
+                nativeTextStart[nativeTextOffset] = 0;
+                nativeTextEnd = nativeTextStart + nativeTextOffset;
+            }
+
+            ImGuiNative.igCalcTextSize(&ret, nativeTextStart, nativeTextEnd, *((byte*)(&hideTextAfterDoubleHash)), wrapWidth);
+            if (textByteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(nativeTextStart);
+            }
+
+            return ret;
+        }
+
+        public static bool InputText(
+            ReadOnlySpan<char> label,
+            IntPtr buf,
+            uint buf_size)
+        {
+            return InputText(label, buf, buf_size, 0, null, IntPtr.Zero);
+        }
+
+        public static bool InputText(
+            ReadOnlySpan<char> label,
+            IntPtr buf,
+            uint buf_size,
+            ImGuiInputTextFlags flags)
+        {
+            return InputText(label, buf, buf_size, flags, null, IntPtr.Zero);
+        }
+
+        public static bool InputText(
+            ReadOnlySpan<char> label,
+            IntPtr buf,
+            uint buf_size,
+            ImGuiInputTextFlags flags,
+            ImGuiInputTextCallback callback)
+        {
+            return InputText(label, buf, buf_size, flags, callback, IntPtr.Zero);
+        }
+
+        public static bool InputText(
+            ReadOnlySpan<char> label,
+            IntPtr buf,
+            uint buf_size,
+            ImGuiInputTextFlags flags,
+            ImGuiInputTextCallback callback,
+            IntPtr user_data)
+        {
+            int utf8LabelByteCount = Encoding.UTF8.GetByteCount(label);
+            byte* utf8LabelBytes;
+            if (utf8LabelByteCount > Util.StackAllocationSizeLimit)
+            {
+                utf8LabelBytes = Util.Allocate(utf8LabelByteCount + 1);
+            }
+            else
+            {
+                byte* stackPtr = stackalloc byte[utf8LabelByteCount + 1];
+                utf8LabelBytes = stackPtr;
+            }
+            Util.GetUtf8(label, utf8LabelBytes, utf8LabelByteCount);
+
+            bool ret = ImGuiNative.igInputText(utf8LabelBytes, (byte*)buf.ToPointer(), buf_size, flags, callback, user_data.ToPointer()) != 0;
+
+            if (utf8LabelByteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(utf8LabelBytes);
+            }
+
+            return ret;
+        }
+
+        public static bool Begin(ReadOnlySpan<char> name, ImGuiWindowFlags flags)
+        {
+            int utf8NameByteCount = Encoding.UTF8.GetByteCount(name);
+            byte* utf8NameBytes;
+            if (utf8NameByteCount > Util.StackAllocationSizeLimit)
+            {
+                utf8NameBytes = Util.Allocate(utf8NameByteCount + 1);
+            }
+            else
+            {
+                byte* stackPtr = stackalloc byte[utf8NameByteCount + 1];
+                utf8NameBytes = stackPtr;
+            }
+            Util.GetUtf8(name, utf8NameBytes, utf8NameByteCount);
+
+            byte* p_open = null;
+            byte ret = ImGuiNative.igBegin(utf8NameBytes, p_open, flags);
+
+            if (utf8NameByteCount > Util.StackAllocationSizeLimit)
+            {
+                Util.Free(utf8NameBytes);
+            }
+
+            return ret != 0;
+        }
+
+        public static bool MenuItem(ReadOnlySpan<char> label, bool enabled)
+        {
+            return MenuItem(label, string.Empty, false, enabled);
+        }
+    }
+}
+#endif

--- a/src/ImGui.NET/ImGui.Manual.cs
+++ b/src/ImGui.NET/ImGui.Manual.cs
@@ -9,11 +9,7 @@ namespace ImGuiNET
     public static unsafe partial class ImGui
     {
         public static bool InputText(
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
-            ReadOnlySpan<char> label,
-#else
             string label,
-#endif
             byte[] buf,
             uint buf_size)
         {
@@ -21,11 +17,7 @@ namespace ImGuiNET
         }
 
         public static bool InputText(
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
-            ReadOnlySpan<char> label,
-#else
             string label,
-#endif
             byte[] buf,
             uint buf_size,
             ImGuiInputTextFlags flags)
@@ -34,11 +26,7 @@ namespace ImGuiNET
         }
 
         public static bool InputText(
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
-            ReadOnlySpan<char> label,
-#else
             string label,
-#endif
             byte[] buf,
             uint buf_size,
             ImGuiInputTextFlags flags,
@@ -48,11 +36,7 @@ namespace ImGuiNET
         }
 
         public static bool InputText(
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
-            ReadOnlySpan<char> label,
-#else
             string label,
-#endif
             byte[] buf,
             uint buf_size,
             ImGuiInputTextFlags flags,
@@ -87,41 +71,25 @@ namespace ImGuiNET
         }
 
         public static bool InputText(
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
-            ReadOnlySpan<char> label,
-#else
             string label,
-#endif
             ref string input,
             uint maxLength) => InputText(label, ref input, maxLength, 0, null, IntPtr.Zero);
 
         public static bool InputText(
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
-            ReadOnlySpan<char> label,
-#else
             string label,
-#endif
             ref string input,
             uint maxLength,
             ImGuiInputTextFlags flags) => InputText(label, ref input, maxLength, flags, null, IntPtr.Zero);
 
         public static bool InputText(
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
-            ReadOnlySpan<char> label,
-#else
             string label,
-#endif
             ref string input,
             uint maxLength,
             ImGuiInputTextFlags flags,
             ImGuiInputTextCallback callback) => InputText(label, ref input, maxLength, flags, callback, IntPtr.Zero);
 
         public static bool InputText(
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
-            ReadOnlySpan<char> label,
-#else
             string label,
-#endif
             ref string input,
             uint maxLength,
             ImGuiInputTextFlags flags,
@@ -189,32 +157,20 @@ namespace ImGuiNET
         }
 
         public static bool InputTextMultiline(
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
-            ReadOnlySpan<char> label,
-#else
             string label,
-#endif
             ref string input,
             uint maxLength,
             Vector2 size) => InputTextMultiline(label, ref input, maxLength, size, 0, null, IntPtr.Zero);
 
         public static bool InputTextMultiline(
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
-            ReadOnlySpan<char> label,
-#else
             string label,
-#endif
             ref string input,
             uint maxLength,
             Vector2 size,
             ImGuiInputTextFlags flags) => InputTextMultiline(label, ref input, maxLength, size, flags, null, IntPtr.Zero);
 
         public static bool InputTextMultiline(
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
-            ReadOnlySpan<char> label,
-#else
             string label,
-#endif
             ref string input,
             uint maxLength,
             Vector2 size,
@@ -222,11 +178,7 @@ namespace ImGuiNET
             ImGuiInputTextCallback callback) => InputTextMultiline(label, ref input, maxLength, size, flags, callback, IntPtr.Zero);
 
         public static bool InputTextMultiline(
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
-            ReadOnlySpan<char> label,
-#else
             string label,
-#endif
             ref string input,
             uint maxLength,
             Vector2 size,
@@ -296,49 +248,29 @@ namespace ImGuiNET
         }
 
         public static bool InputTextWithHint(
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
-            ReadOnlySpan<char> label,
-            ReadOnlySpan<char> hint,
-#else
             string label,
             string hint,
-#endif
             ref string input,
             uint maxLength) => InputTextWithHint(label, hint, ref input, maxLength, 0, null, IntPtr.Zero);
 
         public static bool InputTextWithHint(
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
-            ReadOnlySpan<char> label,
-            ReadOnlySpan<char> hint,
-#else
             string label,
             string hint,
-#endif
             ref string input,
             uint maxLength,
             ImGuiInputTextFlags flags) => InputTextWithHint(label, hint, ref input, maxLength, flags, null, IntPtr.Zero);
 
         public static bool InputTextWithHint(
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
-            ReadOnlySpan<char> label,
-            ReadOnlySpan<char> hint,
-#else
             string label,
             string hint,
-#endif
             ref string input,
             uint maxLength,
             ImGuiInputTextFlags flags,
             ImGuiInputTextCallback callback) => InputTextWithHint(label, hint, ref input, maxLength, flags, callback, IntPtr.Zero);
 
         public static bool InputTextWithHint(
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
-            ReadOnlySpan<char> label,
-            ReadOnlySpan<char> hint,
-#else
             string label,
             string hint,
-#endif
             ref string input,
             uint maxLength,
             ImGuiInputTextFlags flags,
@@ -423,40 +355,6 @@ namespace ImGuiNET
             return result != 0;
         }
 
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
-        public static Vector2 CalcTextSize(ReadOnlySpan<char> text)
-            => CalcTextSizeImpl(text);
-
-        public static Vector2 CalcTextSize(ReadOnlySpan<char> text, int start)
-            => CalcTextSizeImpl(text, start);
-
-        public static Vector2 CalcTextSize(ReadOnlySpan<char> text, float wrapWidth)
-            => CalcTextSizeImpl(text, wrapWidth: wrapWidth);
-
-        public static Vector2 CalcTextSize(ReadOnlySpan<char> text, bool hideTextAfterDoubleHash)
-            => CalcTextSizeImpl(text, hideTextAfterDoubleHash: hideTextAfterDoubleHash);
-
-        public static Vector2 CalcTextSize(ReadOnlySpan<char> text, int start, int length)
-            => CalcTextSizeImpl(text, start, length);
-
-        public static Vector2 CalcTextSize(ReadOnlySpan<char> text, int start, bool hideTextAfterDoubleHash)
-            => CalcTextSizeImpl(text, start, hideTextAfterDoubleHash: hideTextAfterDoubleHash);
-
-        public static Vector2 CalcTextSize(ReadOnlySpan<char> text, int start, float wrapWidth)
-            => CalcTextSizeImpl(text, start, wrapWidth: wrapWidth);
-
-        public static Vector2 CalcTextSize(ReadOnlySpan<char> text, bool hideTextAfterDoubleHash, float wrapWidth)
-            => CalcTextSizeImpl(text, hideTextAfterDoubleHash: hideTextAfterDoubleHash, wrapWidth: wrapWidth);
-
-        public static Vector2 CalcTextSize(ReadOnlySpan<char> text, int start, int length, bool hideTextAfterDoubleHash)
-            => CalcTextSizeImpl(text, start, length, hideTextAfterDoubleHash);
-
-        public static Vector2 CalcTextSize(ReadOnlySpan<char> text, int start, int length, float wrapWidth)
-            => CalcTextSizeImpl(text, start, length, wrapWidth: wrapWidth);
-
-        public static Vector2 CalcTextSize(ReadOnlySpan<char> text, int start, int length, bool hideTextAfterDoubleHash, float wrapWidth)
-            => CalcTextSizeImpl(text, start, length, hideTextAfterDoubleHash, wrapWidth);
-#else
         public static Vector2 CalcTextSize(string text)
             => CalcTextSizeImpl(text);
 
@@ -489,14 +387,9 @@ namespace ImGuiNET
 
         public static Vector2 CalcTextSize(string text, int start, int length, bool hideTextAfterDoubleHash, float wrapWidth)
             => CalcTextSizeImpl(text, start, length, hideTextAfterDoubleHash, wrapWidth);
-#endif
 
         private static Vector2 CalcTextSizeImpl(
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
-            ReadOnlySpan<char> text,
-#else
             string text,
-#endif
             int start = 0,
             int? length = null,
             bool hideTextAfterDoubleHash = false,
@@ -536,11 +429,7 @@ namespace ImGuiNET
         }
 
         public static bool InputText(
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
-            ReadOnlySpan<char> label,
-#else
             string label,
-#endif
             IntPtr buf,
             uint buf_size)
         {
@@ -548,11 +437,7 @@ namespace ImGuiNET
         }
 
         public static bool InputText(
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
-            ReadOnlySpan<char> label,
-#else
             string label,
-#endif
             IntPtr buf,
             uint buf_size,
             ImGuiInputTextFlags flags)
@@ -561,11 +446,7 @@ namespace ImGuiNET
         }
 
         public static bool InputText(
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
-            ReadOnlySpan<char> label,
-#else
             string label,
-#endif
             IntPtr buf,
             uint buf_size,
             ImGuiInputTextFlags flags,
@@ -575,11 +456,7 @@ namespace ImGuiNET
         }
 
         public static bool InputText(
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
-            ReadOnlySpan<char> label,
-#else
             string label,
-#endif
             IntPtr buf,
             uint buf_size,
             ImGuiInputTextFlags flags,
@@ -609,11 +486,7 @@ namespace ImGuiNET
             return ret;
         }
 
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
-        public static bool Begin(ReadOnlySpan<char> name, ImGuiWindowFlags flags)
-#else
         public static bool Begin(string name, ImGuiWindowFlags flags)
-#endif
         {
             int utf8NameByteCount = Encoding.UTF8.GetByteCount(name);
             byte* utf8NameBytes;
@@ -639,11 +512,7 @@ namespace ImGuiNET
             return ret != 0;
         }
 
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
-        public static bool MenuItem(ReadOnlySpan<char> label, bool enabled)
-#else
         public static bool MenuItem(string label, bool enabled)
-#endif
         {
             return MenuItem(label, string.Empty, false, enabled);
         }

--- a/src/TestDotNetStandardLib/TestDotNetStandardLib.csproj
+++ b/src/TestDotNetStandardLib/TestDotNetStandardLib.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\ImGui.NET\ImGui.NET.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/TestDotNetStandardLib/TestStringParameterOnDotNetStandard.cs
+++ b/src/TestDotNetStandardLib/TestStringParameterOnDotNetStandard.cs
@@ -1,0 +1,12 @@
+using ImGuiNET;
+
+namespace TestDotNetStandardLib
+{
+	public static class TestStringParameterOnDotNetStandard
+	{
+		public static void Text()
+		{
+			ImGui.Text(".NET Standard 2.0 test!");
+		}
+	}
+}


### PR DESCRIPTION
- Fixes #436
- Updates the code generator to always include overloads with string parameters regardless of the target framework, methods with `ReadOnlySpan<char>` overloads are still supported
- Adds a .NET Standard 2.0 test library to the sample to make sure this doesn't happen again (I don't know if it's possible to write a unit/integration test for this but that would probably be way better)
- Removes all target directives and `ReadOnlySpan<char>` usages from ImGui.Manual.cs
- Adds a copy of ImGui.Manual.cs (ImGui.Manual.ReadOnlySpan.cs) which includes `ReadOnlySpan<char>` overloads

If the tests in the sample project are not needed I'm fine with removing them. Please let me know if I've missed anything. Any feedback is appreciated.